### PR TITLE
disable separateRgbManagement by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ The end result in the `settings.json` file should look something like this:
 
 4. reboot
 
+# Troubleshooting / Frequently Asked Questions
+
+## Can I set RGB LEDs separately between the Left and Right LEDs?
+
+Due to a controller firmware update, Lenovo disabled the ability to set the LEDs separately.
+
+If you are on the older firmware, you can manually enable separate LED management by adding the following to your `$HOME/homebrew/settings/LegionGoRemapper/settings.json`:
+
+```
+forceEnableSeparateLedManagement: true
+```
+
 # Attribution
 
 Special thanks to [antheas](https://github.com/antheas) for [reverse engineering and documenting the HID protocols](https://github.com/antheas/hwinfo/tree/master/devices/legion_go) for the Legion Go Controllers, etc.

--- a/py_modules/rgb.py
+++ b/py_modules/rgb.py
@@ -7,8 +7,15 @@ import controller_settings as settings
 # sync the state of the RGB lights to the values in settings.json
 def sync_rgb_settings(current_game_id):
     s = settings.get_settings()
+    enable_separate_rgb_management = s.get('forceEnableSeparateLedManagement', False)
+
+    controllers = ['RIGHT']
+
+    if enable_separate_rgb_management:
+        controllers.append('LEFT')
+
     rgb_profile = s.get('rgb').get(current_game_id)
-    for controller in ['LEFT', 'RIGHT']:
+    for controller in controllers:
         rgb_light = rgb_profile.get(controller)
         rgb_mode = rgb_light.get('mode')
 

--- a/src/components/rgb/ControllerLightingPanel.tsx
+++ b/src/components/rgb/ControllerLightingPanel.tsx
@@ -1,6 +1,10 @@
 import { PanelSection } from 'decky-frontend-lib';
 import { VFC } from 'react';
-import { useEnableRgbControl, useRgbProfileDisplayName } from '../../hooks/rgb';
+import {
+  useEnableRgbControl,
+  useRgbProfileDisplayName,
+  useSeparateRgbManagementEnabled
+} from '../../hooks/rgb';
 import { RgbPerGameProfilesToggle } from './RgbPerGameProfilesToggle';
 import { RgbSettings } from './RgbSettings';
 import { EnableRgbControlToggle } from './EnableRgbControlToggle';
@@ -8,6 +12,7 @@ import { EnableRgbControlToggle } from './EnableRgbControlToggle';
 const ControllerLightingPanel: VFC = () => {
   const displayName = useRgbProfileDisplayName();
   const { rgbControlEnabled } = useEnableRgbControl();
+  const separateRgbManagementEnabled = useSeparateRgbManagementEnabled();
 
   let title =
     displayName === 'Default'
@@ -22,7 +27,7 @@ const ControllerLightingPanel: VFC = () => {
           <>
             <RgbPerGameProfilesToggle />
             <RgbSettings controller="RIGHT" />
-            <RgbSettings controller="LEFT" />
+            {separateRgbManagementEnabled && <RgbSettings controller="LEFT" />}
           </>
         )}
       </div>

--- a/src/components/rgb/RgbSettings.tsx
+++ b/src/components/rgb/RgbSettings.tsx
@@ -5,7 +5,11 @@ import {
   gamepadSliderClasses
 } from 'decky-frontend-lib';
 import { FC, useState } from 'react';
-import { useRgb, useRgbMode } from '../../hooks/rgb';
+import {
+  useRgb,
+  useRgbMode,
+  useSeparateRgbManagementEnabled
+} from '../../hooks/rgb';
 import RgbModeSlider from './RgbModeSlider';
 import { RgbModes, ControllerType } from '../../backend/constants';
 import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io';
@@ -15,23 +19,25 @@ const labelMap = {
   LEFT: 'Left'
 };
 
-const HIDE_COLOR_PICKER_MODES = [
-  RgbModes.DYNAMIC,
-  RgbModes.SPIRAL
-]
+const HIDE_COLOR_PICKER_MODES = [RgbModes.DYNAMIC, RgbModes.SPIRAL];
 
 export const RgbSettings: FC<{ controller: ControllerType }> = ({
   controller
 }) => {
   const rgb = useRgb(controller);
+  const separateRgbManagementEnabled = useSeparateRgbManagementEnabled();
   const { enabled, brightness, speed, hue } = rgb.rgbInfo;
   const [showOptions, setShowOptions] = useState(false);
   const [mode] = useRgbMode(controller);
 
+  const label = separateRgbManagementEnabled
+    ? `${labelMap[controller]} Controller LED`
+    : 'Controller LED';
+
   return (
     <>
       <ToggleField
-        label={`${labelMap[controller]} Controller LED`}
+        label={label}
         checked={enabled}
         onChange={rgb.setEnabled}
         bottomSeparator={enabled ? 'none' : 'thick'}
@@ -58,7 +64,7 @@ export const RgbSettings: FC<{ controller: ControllerType }> = ({
         <>
           <RgbModeSlider controller={controller} />
           <SliderField
-            label={`${controller[0]}-Stick Brightness`}
+            label={`Brightness`}
             valueSuffix="%"
             value={brightness}
             showValue={true}

--- a/src/hooks/rgb.tsx
+++ b/src/hooks/rgb.tsx
@@ -7,7 +7,8 @@ import {
   selectRgbProfileDisplayName,
   selectPerGameProfilesEnabled,
   selectRgbMode,
-  selectEnableRgbControl
+  selectEnableRgbControl,
+  selectSeparateRgbManagementEnabled
 } from '../redux-modules/rgbSlice';
 
 export enum Colors {
@@ -15,6 +16,11 @@ export enum Colors {
   GREEN = 'green',
   BLUE = 'blue'
 }
+
+export const useSeparateRgbManagementEnabled = () => {
+  const enabled = useSelector(selectSeparateRgbManagementEnabled);
+  return enabled;
+};
 
 export const useEnableRgbControl = () => {
   const enabled = useSelector(selectEnableRgbControl);

--- a/src/redux-modules/rgbSlice.tsx
+++ b/src/redux-modules/rgbSlice.tsx
@@ -45,12 +45,14 @@ type RgbState = {
   rgbProfiles: RgbProfiles;
   perGameProfilesEnabled: boolean;
   enableRgbControl: boolean;
+  forceEnableSeparateLedManagement: boolean;
 };
 
 const initialState: RgbState = {
   rgbProfiles: {},
   perGameProfilesEnabled: false,
-  enableRgbControl: true
+  enableRgbControl: true,
+  forceEnableSeparateLedManagement: false
 };
 
 const bootstrapRgbProfile = (state: RgbState, newGameId: string) => {
@@ -224,6 +226,9 @@ export const rgbSlice = createSlice({
       state.rgbProfiles = rgbProfiles;
       state.enableRgbControl = enableRgbControl;
       state.perGameProfilesEnabled = perGameProfilesEnabled;
+      state.forceEnableSeparateLedManagement = Boolean(
+        action.payload.forceEnableSeparateLedManagement
+      );
     });
     builder.addCase(setCurrentGameId, (state, action) => {
       /*
@@ -280,6 +285,10 @@ export const selectRgbProfileDisplayName = (state: RootState) => {
 
 export const selectEnableRgbControl = (state: RootState) => {
   return Boolean(state.rgb.enableRgbControl);
+};
+
+export const selectSeparateRgbManagementEnabled = (state: RootState) => {
+  return Boolean(state.rgb.forceEnableSeparateLedManagement);
 };
 
 // -------------


### PR DESCRIPTION
Lenovo pushed a controller firmware update that disallows managing separate LED lights on the controller.

This update disables controlling both LEDs by default, but can still be manually enabled via a settings override (described in the README)