### PR TITLE
Fix controller ID lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Legion Go Remapper - Decky Plugin
 
-[![](https://img.shields.io/github/downloads/aarron-lee/LegionGoRemapper/total.svg)](https://github.com/aarron-lee/LegionGoRemapper/releases)
+[![](https://img.shields.io/github/downloads/InnoVision-Games/LegionGoRemapper/total.svg)](https://github.com/InnoVision-Games/LegionGoRemapper/releases)
 
 Decky Plugin that replicates some of the Legion Space remapping functionality, currently only for the original Legion Go Z1E.
 
@@ -57,7 +57,7 @@ For the **Legion Go S**, see Huesync for RGB controls: https://github.com/honjow
 Run the following in terminal, then reboot. Note that this works both for installing or updating the plugin
 
 ```
-curl -L https://github.com/aarron-lee/LegionGoRemapper/raw/main/install.sh | sh
+curl -L https://github.com/InnoVision-Games/LegionGoRemapper/raw/main/install.sh | sh
 ```
 
 ### Manual Install
@@ -80,7 +80,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="17ef", MODE="0666"
 
 After saving the file, then run `sudo udevadm control --reload` in terminal.
 
-Download the latest release from the [releases page](https://github.com/aarron-lee/LegionGoRemapper/releases)
+Download the latest release from the [releases page](https://github.com/InnoVision-Games/LegionGoRemapper/releases)
 
 Unzip the `tar.gz` file, and move the `LegionGoRemapper` folder to your `$HOME/homebrew/plugins` directory
 
@@ -97,7 +97,7 @@ then reboot your machine.
 - Node.js v16.14+ and pnpm installed
 
 ```bash
-git clone https://github.com/aarron-lee/LegionGoRemapper.git
+git clone https://github.com/InnoVision-Games/LegionGoRemapper.git
 
 cd LegionGoRemapper
 
@@ -156,7 +156,7 @@ If you are on the latest firmware, the plugin will update both LEDs.
 First try reinstalling or updating the plugin to the latest version, there's an update button at the bottom of the plugin. You can also re-run the installer to update:
 
 ```
-curl -L https://github.com/aarron-lee/LegionGoRemapper/raw/main/install.sh | sh
+curl -L https://github.com/InnoVision-Games/LegionGoRemapper/raw/main/install.sh | sh
 ```
 
 If this doesn't fix your issue, next try deleting your `$HOME/homebrew/settings/LegionGoRemapper/settings.json` file, and rebooting.

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ fi
 
 echo "installing LegionGoRemapper plugin for RGB control"
 # download + install Legion go remapper
-curl -L $(curl -s https://api.github.com/repos/aarron-lee/LegionGoRemapper/releases/latest | grep "browser_download_url" | cut -d '"' -f 4) -o $HOME/LegionGoRemapper.tar.gz
+curl -L $(curl -s https://api.github.com/repos/InnoVision-Games/LegionGoRemapper/releases/latest | grep "browser_download_url" | cut -d '"' -f 4) -o $HOME/LegionGoRemapper.tar.gz
 sudo tar -xzf LegionGoRemapper.tar.gz -C $HOME/homebrew/plugins
 
 # install complete, remove build dir

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-typescript": "^8.3.3",
     "@types/react": "16.14.0",
     "@types/webpack": "^5.28.0",
-    "decky-frontend-lib": "^3.24.5",
+    "decky-frontend-lib": "^3.25.0",
     "rollup": "^2.77.1",
     "rollup-plugin-import-assets": "^1.1.1",
     "shx": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,8 +47,8 @@ devDependencies:
     specifier: ^5.28.0
     version: 5.28.1
   decky-frontend-lib:
-    specifier: ^3.24.5
-    version: 3.24.5
+    specifier: ^3.25.0
+    version: 3.25.0
   rollup:
     specifier: ^2.77.1
     version: 2.79.1
@@ -486,8 +486,8 @@ packages:
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
-  /decky-frontend-lib@3.24.5:
-    resolution: {integrity: sha512-eYlbKDOOcIBPI0b76Rqvlryq2ym/QNiry4xf2pFrXmBa1f95dflqbQAb2gTq9uHEa5gFmeV4lUcMPGJ3M14Xqw==}
+  /decky-frontend-lib@3.25.0:
+    resolution: {integrity: sha512-2lBoHS2AIRmuluq/bGdHBz+uyToQE7k3K/vDq1MQbDZ4eC+8CGDuh2T8yZOj3D0yjGP2MdikNNAWPA9Z5l2qDg==}
     dev: true
 
   /deepmerge@4.3.1:

--- a/test.py
+++ b/test.py
@@ -1,16 +1,28 @@
 import hid
 import time
-# Global variables
+
+# Lenovo Vendor ID
 vendor_id = 0x17EF
-product_id_match = lambda x: x & 0xFFF0 == 0x6180
+
+# Legion Go controller product IDs
+base_product_ids = [
+    # Legion Go controllers with firmwares from before 2025
+    0x6180,
+    # Legion Go controllers with firmwares from 2025 and after
+    0x61E0,
+]
+
+# Vendor defined HID usage page
 usage_page = 0xFFA0
 global_config = None  # Global configuration for the device
 
 # Enumerate and set the global configuration
 for dev in hid.enumerate(vendor_id):
-    if product_id_match(dev["product_id"]) and dev["usage_page"] == usage_page:
-        global_config = dev
-        break
+    for product_id in base_product_ids:
+        product_id_match = lambda x: x & 0xFFF0 == product_id
+        if product_id_match(dev["product_id"]) and dev["usage_page"] == usage_page:
+            global_config = dev
+            break
 
 if not global_config:
     print("Legion go configuration device not found.")


### PR DESCRIPTION
A handful of commits for updating the controller IDs and lookup logic for supporting both the old and latest controller firmware.

I am unable to test on the previous firmware version, but tried to make the code version agnostic.

Please feel free to disregard the commit that change the repo paths, as this was done to make it easier for me to test.