### PR TITLE
Add Legion Go 2 brightness support and brightness offset slider

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,10 +5,12 @@ import logging
 # For easy intellisense checkout the decky-loader code one directory up
 # or add the `decky-loader/plugin` path to `python.analysis.extraPaths` in `.vscode/settings.json`
 
+import asyncio
 import decky_plugin
 import ambient_light_sensor
 import legion_configurator
 import legion_space
+import legion_go2_brightness
 import controller_enums
 import rgb
 import controllers
@@ -33,6 +35,12 @@ class Plugin:
     async def _main(self):
         decky_plugin.logger.info("Hello World!")
 
+        if legion_go2_brightness.is_legion_go_2():
+            decky_plugin.logger.info("Legion Go 2 detected, starting backlight watcher")
+            self._backlight_task = asyncio.create_task(
+                legion_go2_brightness.backlight_watcher_loop()
+            )
+
     async def get_settings(self):
         results = settings.get_settings()
 
@@ -41,6 +49,8 @@ class Plugin:
 
         try:
             results['pluginVersionNum'] = f'{decky_plugin.DECKY_PLUGIN_VERSION}'
+
+            results['isLegionGo2'] = legion_go2_brightness.is_legion_go_2()
 
             if settings.supports_custom_fan_curves():
                 results['supportsCustomFanCurves'] = True
@@ -160,11 +170,18 @@ class Plugin:
         except Exception as e:
             decky_plugin.logger.error(f'error while setting charge limit {e}')
 
+    async def is_legion_go_2(self):
+        return legion_go2_brightness.is_legion_go_2()
+
     async def set_als_enabled(self, enabled):
         try:
             settings.set_setting('alsEnabled', enabled)
         except Exception as e:
             decky_plugin.logger.error(f'error while setting als {e}')
+
+    async def set_gamescope_brightness_pct(self, pct):
+        legion_go2_brightness.set_gamescope_brightness_pct(pct)
+
 
     async def save_settings(self, new_settings):
         try:
@@ -204,7 +221,9 @@ class Plugin:
     # Function called first during the unload process, utilize this to handle your plugin being removed
     async def _unload(self):
         decky_plugin.logger.info("Goodbye World!")
-        pass
+        legion_go2_brightness.stop_backlight_watcher()
+        if hasattr(self, '_backlight_task'):
+            self._backlight_task.cancel()
 
     # Migrations that should be performed before entering `_main()`.
     async def _migration(self):

--- a/py_modules/legion_go2_brightness.py
+++ b/py_modules/legion_go2_brightness.py
@@ -1,0 +1,244 @@
+import os
+import pwd
+import struct
+import ctypes
+import ctypes.util
+import asyncio
+import decky_plugin
+
+GAMESCOPE_DISPLAY = ":0"
+BACKLIGHT_PATH = "/sys/class/backlight/amdgpu_bl1"
+BRIGHTNESS_FILE = os.path.join(BACKLIGHT_PATH, "brightness")
+MAX_BRIGHTNESS_FILE = os.path.join(BACKLIGHT_PATH, "max_brightness")
+
+MIN_NITS = 5.0
+MAX_NITS = 500.0
+
+_watcher_running = False
+_last_brightness_value = -1
+_gamescope_user = None
+
+# libX11 handle (loaded once)
+_libX11 = None
+_x11_setup_done = False
+
+
+def _load_libx11():
+    """Load libX11.so and set up ctypes signatures."""
+    global _libX11, _x11_setup_done
+    if _x11_setup_done:
+        return _libX11
+
+    _x11_setup_done = True
+    path = ctypes.util.find_library("X11")
+    if not path:
+        decky_plugin.logger.error("libX11 not found")
+        return None
+
+    try:
+        lib = ctypes.CDLL(path)
+        lib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+        lib.XOpenDisplay.restype = ctypes.c_void_p
+        lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+        lib.XCloseDisplay.restype = ctypes.c_int
+        lib.XDefaultRootWindow.argtypes = [ctypes.c_void_p]
+        lib.XDefaultRootWindow.restype = ctypes.c_ulong
+        lib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+        lib.XInternAtom.restype = ctypes.c_ulong
+        lib.XChangeProperty.argtypes = [
+            ctypes.c_void_p, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong,
+            ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.c_ubyte), ctypes.c_int
+        ]
+        lib.XChangeProperty.restype = ctypes.c_int
+        lib.XFlush.argtypes = [ctypes.c_void_p]
+        lib.XFlush.restype = ctypes.c_int
+
+        _libX11 = lib
+        decky_plugin.logger.info(f"Loaded libX11 from {path}")
+        return lib
+    except Exception as e:
+        decky_plugin.logger.error(f"Failed to load libX11: {e}")
+        return None
+
+
+def is_legion_go_2():
+    try:
+        with open("/sys/devices/virtual/dmi/id/chassis_version", "r") as f:
+            version = f.read().strip()
+            return "Legion Go 8ASP2" in version
+    except OSError:
+        return False
+
+
+def _find_gamescope_user():
+    """Find the UID/GID of the user running gamescope.
+
+    Scans /proc directly instead of using pgrep to avoid PATH issues
+    in systemd service contexts.
+
+    Returns (username, uid, gid) or None.
+    """
+    global _gamescope_user
+    if _gamescope_user is not None:
+        return _gamescope_user
+
+    # Try /proc scan for gamescope process
+    try:
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            try:
+                with open(f"/proc/{entry}/comm", "r") as f:
+                    comm = f.read().strip()
+                if not comm.startswith("gamescope"):
+                    continue
+                stat = os.stat(f"/proc/{entry}")
+                if stat.st_uid == 0:
+                    continue
+                pw = pwd.getpwuid(stat.st_uid)
+                _gamescope_user = (pw.pw_name, pw.pw_uid, pw.pw_gid)
+                return _gamescope_user
+            except (OSError, KeyError, ValueError):
+                continue
+    except Exception as e:
+        decky_plugin.logger.error(f"/proc scan failed: {e}")
+
+    # Fallback: use X11 socket owner
+    try:
+        stat = os.stat("/tmp/.X11-unix/X0")
+        if stat.st_uid != 0:
+            pw = pwd.getpwuid(stat.st_uid)
+            _gamescope_user = (pw.pw_name, pw.pw_uid, pw.pw_gid)
+            return _gamescope_user
+    except (OSError, KeyError) as e:
+        decky_plugin.logger.error(f"X socket fallback failed: {e}")
+
+    decky_plugin.logger.warning("Could not find gamescope process owner")
+    return None
+
+
+
+def _read_max_brightness():
+    try:
+        with open(MAX_BRIGHTNESS_FILE, "r") as f:
+            return int(f.read().strip())
+    except OSError as e:
+        decky_plugin.logger.error(f"Failed to read max brightness: {e}")
+        return 471000  # fallback default for LGo2
+
+
+def _read_brightness():
+    try:
+        with open(BRIGHTNESS_FILE, "r") as f:
+            return int(f.read().strip())
+    except OSError as e:
+        decky_plugin.logger.error(f"Failed to read brightness: {e}")
+        return None
+
+
+def _pct_to_nits(pct):
+    """Convert a brightness percentage (0-100) to nits (5-500)."""
+    ratio = max(0.0, min(100.0, pct)) / 100.0
+    return MIN_NITS + ratio * (MAX_NITS - MIN_NITS)
+
+
+def backlight_to_nits(bl_value, max_bl):
+    ratio = bl_value / max_bl
+    return MIN_NITS + ratio * (MAX_NITS - MIN_NITS)
+
+
+def nits_to_gamescope_int(nits):
+    """Pack a float nits value as a 32-bit unsigned int for the gamescope atom."""
+    float_bytes = struct.pack('f', nits)
+    return struct.unpack('I', float_bytes)[0]
+
+
+def set_gamescope_brightness(nits):
+    nits = max(MIN_NITS, min(MAX_NITS, nits))
+    int_val = nits_to_gamescope_int(nits)
+
+    lib = _load_libx11()
+    if lib is None:
+        return
+
+    user_info = _find_gamescope_user()
+
+    # Switch to gamescope user's credentials before opening the display.
+    # We need to switch and switch back since this runs in the main process.
+    original_uid = os.getuid()
+    original_gid = os.getgid()
+    original_groups = os.getgroups()
+    switched = False
+
+    try:
+        if user_info and original_uid == 0:
+            username, uid, gid = user_info
+            os.setegid(gid)
+            os.initgroups(username, gid)
+            os.seteuid(uid)
+            switched = True
+
+        display = lib.XOpenDisplay(GAMESCOPE_DISPLAY.encode())
+        if not display:
+            decky_plugin.logger.error("Failed to open X display :0 via libX11")
+            return
+
+        try:
+            root = lib.XDefaultRootWindow(display)
+            atom_name = b"GAMESCOPE_SDR_ON_HDR_CONTENT_BRIGHTNESS"
+            atom = lib.XInternAtom(display, atom_name, 0)
+            cardinal = lib.XInternAtom(display, b"CARDINAL", 0)
+
+            # Pack the value as a 32-bit array (one element)
+            data = (ctypes.c_ubyte * 4)(*struct.pack('I', int_val))
+
+            # PropModeReplace = 0, format = 32, nelements = 1
+            lib.XChangeProperty(display, root, atom, cardinal, 32, 0, data, 1)
+            lib.XFlush(display)
+        finally:
+            lib.XCloseDisplay(display)
+    except Exception as e:
+        decky_plugin.logger.error(f"Failed to set gamescope brightness: {e}")
+    finally:
+        if switched:
+            os.seteuid(original_uid)
+            os.setegid(original_gid)
+            os.setgroups(original_groups)
+
+
+def set_gamescope_brightness_pct(pct):
+    """Set gamescope brightness from a 0-100 percentage. Used by ALS on LGo2."""
+    nits = _pct_to_nits(pct)
+    set_gamescope_brightness(nits)
+
+
+async def backlight_watcher_loop():
+    """Poll sysfs backlight and bridge changes to gamescope atom.
+
+    Watches for sysfs brightness changes (from Steam slider) and reflects
+    them to gamescope's HDR brightness atom.
+    """
+    global _watcher_running, _last_brightness_value
+
+    _watcher_running = True
+    max_bl = _read_max_brightness()
+    decky_plugin.logger.info(
+        f"Starting LGo2 backlight watcher (max_brightness={max_bl})"
+    )
+
+    while _watcher_running:
+        await asyncio.sleep(0.05)  # 50ms polling
+
+        bl_value = _read_brightness()
+        if bl_value is None or bl_value == _last_brightness_value:
+            continue
+
+        _last_brightness_value = bl_value
+        nits = backlight_to_nits(bl_value, max_bl)
+        set_gamescope_brightness(nits)
+
+
+def stop_backlight_watcher():
+    global _watcher_running
+    _watcher_running = False
+    decky_plugin.logger.info("Stopping LGo2 backlight watcher")

--- a/src/backend/alsListener.tsx
+++ b/src/backend/alsListener.tsx
@@ -29,6 +29,7 @@ const BRIGHTNESS_THRESHOLDS = [
 
 let steamRegistration: any;
 let enableAdaptiveBrightness = false;
+let isLegionGo2Device = false;
 
 export const sensitivityInfo = {
   range: [25, 100],
@@ -45,13 +46,20 @@ export const smoothTimeInfo = {
   step: 50
 };
 
+export const brightnessOffsetInfo = {
+  range: [-30, 30],
+  step: 5
+};
+
 export const DEFAULT_POLLING_RATE = 100;
 export const DEFAULT_SMOOTH_TIME = 500;
 export const DEFAULT_SENSITIVITY = 50;
+export const DEFAULT_BRIGHTNESS_OFFSET = 0;
 
 let pollingRate = DEFAULT_POLLING_RATE; // Time in milliseconds
 let smoothTime = DEFAULT_SMOOTH_TIME; // Time in milliseconds
 const stepCount = 10; // Less steps = smoother transition
+let brightnessOffset = DEFAULT_BRIGHTNESS_OFFSET;
 
 let previousAlsValues = Array(DEFAULT_SENSITIVITY).fill(-1); // Increase length to increase read times (less sensitive to changes)
 let currentBrightness = 50;
@@ -65,7 +73,8 @@ const handleAls = async () => {
     return;
   }
 
-  const { readAls } = createServerApiHelpers(serverAPI);
+  const { readAls, setGamescopeBrightnessPct } =
+    createServerApiHelpers(serverAPI);
 
   while (enableAdaptiveBrightness) {
     await sleep(pollingRate);
@@ -102,6 +111,9 @@ const handleAls = async () => {
       }
     }
 
+    // Apply brightness offset
+    targetBrightness = Math.min(100, Math.max(0, targetBrightness + brightnessOffset));
+
     if (targetBrightness === currentBrightness) {
       continue;
     }
@@ -127,9 +139,13 @@ const handleAls = async () => {
         `Setting brightness to ${localCurrentBrightness}, target: ${targetBrightness}, brightnessPerStep: ${brightnessPerStep}`
       );
 
-      window.SteamClient.System.Display.SetBrightness(
-        localCurrentBrightness / 100
-      );
+      if (isLegionGo2Device) {
+        await setGamescopeBrightnessPct(localCurrentBrightness);
+      } else {
+        window.SteamClient.System.Display.SetBrightness(
+          localCurrentBrightness / 100
+        );
+      }
     }
 
     currentBrightness = targetBrightness;
@@ -168,4 +184,28 @@ export const clearAlsListener = () => {
 
 export const setSensitivity = (arrSize: number) => {
   previousAlsValues = Array(arrSize).fill(-1);
+};
+
+export const setBrightnessOffset = (offset: number) => {
+  const delta = offset - brightnessOffset;
+  brightnessOffset = offset;
+  if (!enableAdaptiveBrightness || delta === 0) return;
+
+  const newTarget = Math.min(100, Math.max(0, currentBrightness + delta));
+  if (newTarget === currentBrightness) return;
+
+  currentBrightness = newTarget;
+  const serverAPI = getServerApi();
+  if (!serverAPI) return;
+  const { setGamescopeBrightnessPct } = createServerApiHelpers(serverAPI);
+
+  if (isLegionGo2Device) {
+    setGamescopeBrightnessPct(newTarget);
+  } else {
+    window.SteamClient.System.Display.SetBrightness(newTarget / 100);
+  }
+};
+
+export const setIsLegionGo2 = (val: boolean) => {
+  isLegionGo2Device = val;
 };

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -79,6 +79,17 @@ const createGetSettings = (serverAPI: ServerAPI) => async () => {
   return await serverAPI.callPluginMethod(ServerAPIMethods.GET_SETTINGS, {});
 };
 
+const createIsLegionGo2 = (serverAPI: ServerAPI) => async () => {
+  const { result } = await serverAPI.callPluginMethod('is_legion_go_2', {});
+  return Boolean(result);
+};
+
+const createSetGamescopeBrightnessPct =
+  (serverAPI: ServerAPI) => async (pct: number) => {
+    await serverAPI.callPluginMethod('set_gamescope_brightness_pct', { pct });
+  };
+
+
 let serverApi: undefined | ServerAPI;
 
 export const saveServerApi = (s: ServerAPI) => {
@@ -106,7 +117,9 @@ export const createServerApiHelpers = (serverAPI: ServerAPI) => {
     setChargeLimit: createSetChargeLimit(serverAPI),
     readAls: readAls(serverAPI),
     setAlsEnabled: createSetAlsEnabled(serverAPI),
-    saveSettings: createSaveSettings(serverAPI)
+    saveSettings: createSaveSettings(serverAPI),
+    isLegionGo2: createIsLegionGo2(serverAPI),
+    setGamescopeBrightnessPct: createSetGamescopeBrightnessPct(serverAPI)
   };
 };
 

--- a/src/components/als/ALSPanel.tsx
+++ b/src/components/als/ALSPanel.tsx
@@ -8,11 +8,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   selectAlsEnabled,
   selectAlsPollingRate,
+  selectBrightnessOffset,
   selectSensitivity,
   selectSmoothTime,
   uiSlice
 } from '../../redux-modules/uiSlice';
 import {
+  brightnessOffsetInfo,
   pollInfo,
   sensitivityInfo,
   smoothTimeInfo
@@ -53,6 +55,17 @@ const useSensitivity = () => {
   return { sensitivity, setSensitivity };
 };
 
+const useBrightnessOffset = () => {
+  const brightnessOffset = useSelector(selectBrightnessOffset);
+  const dispatch = useDispatch();
+
+  const setBrightnessOffset = (val: number) => {
+    return dispatch(uiSlice.actions.setBrightnessOffset(val));
+  };
+
+  return { brightnessOffset, setBrightnessOffset };
+};
+
 const useSmoothTime = () => {
   const smoothTime = useSelector(selectSmoothTime);
   const dispatch = useDispatch();
@@ -69,10 +82,12 @@ export default function () {
   const { pollingRate, setPollingRate } = useAlsPollingRate();
   const { smoothTime, setSmoothTime } = useSmoothTime();
   const { sensitivity, setSensitivity } = useSensitivity();
+  const { brightnessOffset, setBrightnessOffset } = useBrightnessOffset();
 
   const [minPollRate, maxPollRate] = pollInfo.range;
   const [minSmoothTime, maxSmoothTime] = smoothTimeInfo.range;
   const [minSensitivity, maxSensitivity] = sensitivityInfo.range;
+  const [minOffset, maxOffset] = brightnessOffsetInfo.range;
 
   return (
     <>
@@ -118,6 +133,18 @@ export default function () {
                 max={maxSmoothTime}
                 onChange={setSmoothTime}
                 step={smoothTimeInfo.step}
+                notchTicksVisible
+                showValue
+              />
+            </PanelSectionRow>
+            <PanelSectionRow>
+              <SliderField
+                label="Brightness Offset"
+                value={brightnessOffset}
+                min={minOffset}
+                max={maxOffset}
+                onChange={setBrightnessOffset}
+                step={brightnessOffsetInfo.step}
                 notchTicksVisible
                 showValue
               />

--- a/src/redux-modules/uiSlice.tsx
+++ b/src/redux-modules/uiSlice.tsx
@@ -8,11 +8,14 @@ import {
   getServerApi
 } from '../backend/utils';
 import {
+  DEFAULT_BRIGHTNESS_OFFSET,
   DEFAULT_POLLING_RATE,
   DEFAULT_SENSITIVITY,
   DEFAULT_SMOOTH_TIME,
   clearAlsListener,
   enableAlsListener,
+  setBrightnessOffset,
+  setIsLegionGo2,
   setPollRate,
   setSensitivity,
   setSmoothTime
@@ -30,6 +33,7 @@ type UiStateType = {
     pollingRate: number;
     smoothTime: number;
     sensitivity: number;
+    brightnessOffset: number;
   };
 };
 
@@ -42,7 +46,8 @@ const initialState: UiStateType = {
   alsInfo: {
     pollingRate: DEFAULT_POLLING_RATE,
     smoothTime: DEFAULT_SMOOTH_TIME,
-    sensitivity: DEFAULT_SENSITIVITY
+    sensitivity: DEFAULT_SENSITIVITY,
+    brightnessOffset: DEFAULT_BRIGHTNESS_OFFSET
   }
 };
 
@@ -71,6 +76,10 @@ export const uiSlice = createSlice({
     setSensitivity(state, action: PayloadAction<number>) {
       setSensitivity(action.payload);
       state.alsInfo.sensitivity = action.payload;
+    },
+    setBrightnessOffset(state, action: PayloadAction<number>) {
+      setBrightnessOffset(action.payload);
+      state.alsInfo.brightnessOffset = action.payload;
     }
   },
   extraReducers: (builder) => {
@@ -79,6 +88,9 @@ export const uiSlice = createSlice({
       if (action.payload?.pluginVersionNum) {
         state.pluginVersionNum = `${action.payload.pluginVersionNum}`;
       }
+      if (action.payload?.isLegionGo2) {
+        setIsLegionGo2(true);
+      }
       if (action.payload?.chargeLimitEnabled) {
         state.chargeLimitEnabled = Boolean(action.payload?.chargeLimitEnabled);
       }
@@ -86,12 +98,13 @@ export const uiSlice = createSlice({
         state.alsEnabled = Boolean(action.payload?.alsEnabled);
       }
       if (action.payload?.alsInfo) {
-        const { pollingRate, smoothTime, sensitivity } =
+        const { pollingRate, smoothTime, sensitivity, brightnessOffset: savedOffset } =
           action.payload.alsInfo || {};
         state.alsInfo = { ...state.alsInfo, ...action.payload.alsInfo };
         setPollRate(pollingRate || DEFAULT_POLLING_RATE);
         setSmoothTime(smoothTime || DEFAULT_SMOOTH_TIME);
         setSensitivity(sensitivity || DEFAULT_SENSITIVITY);
+        setBrightnessOffset(savedOffset ?? DEFAULT_BRIGHTNESS_OFFSET);
       }
     });
     builder.addCase(setCurrentGameId, (state, action) => {
@@ -126,6 +139,8 @@ export const selectSmoothTime = (state: RootState) =>
   state.ui.alsInfo.smoothTime;
 export const selectSensitivity = (state: RootState) =>
   state.ui.alsInfo.sensitivity;
+export const selectBrightnessOffset = (state: RootState) =>
+  state.ui.alsInfo.brightnessOffset;
 
 export const uiSliceMiddleware =
   (_store: any) => (next: any) => (action: any) => {
@@ -154,6 +169,10 @@ export const uiSliceMiddleware =
       }
       if (type === uiSlice.actions.setSensitivity.type) {
         const alsInfo = { sensitivity: action.payload };
+        saveSettings({ alsInfo });
+      }
+      if (type === uiSlice.actions.setBrightnessOffset.type) {
+        const alsInfo = { brightnessOffset: action.payload };
         saveSettings({ alsInfo });
       }
 


### PR DESCRIPTION
## Summary

- Add backlight daemon for LGo2 that bridges sysfs brightness changes to gamescope's HDR brightness atom (`GAMESCOPE_SDR_ON_HDR_CONTENT_BRIGHTNESS`), since direct sysfs writes have no visible effect in HDR mode. This is done through libX11 with seteuid to authenticate against gamescope's Xwayland from Decky's root service context
- Detects LGo2 via `/sys/devices/virtual/dmi/id/chassis_version`
- ALS auto-brightness on LGo2 sets the gamescope atom directly instead of using `SetBrightness`
- Add brightness offset slider (-30 to +30) that shifts the ALS brightness curve up/down

## Changes

- `py_modules/legion_go2_brightness.py` - new module: device detection, gamescope brightness control via libX11/ctypes, backlight watcher daemon
- `main.py` - auto-start backlight watcher on LGo2, expose new API methods
- `src/backend/alsListener.tsx` - LGo2 gamescope brightness path, brightness offset support
- `src/backend/utils.tsx` - helpers for `is_legion_go_2`, `set_gamescope_brightness_pct`
- `src/components/als/ALSPanel.tsx` - brightness offset slider UI
- `src/redux-modules/uiSlice.tsx` - brightness offset state, LGo2 flag handling