### PR TITLE
Add ACPI fan support repair UI and full-speed threshold toggle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/LegionFanFix"]
+	path = submodules/LegionFanFix
+	url = git@github.com:kjroberts39/LegionFanFix.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/LegionFanFix"]
-	path = submodules/LegionFanFix
-	url = git@github.com:kjroberts39/LegionFanFix.git

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import logging
 import asyncio
 import decky_plugin
 import ambient_light_sensor
+import fan_support
 import legion_configurator
 import legion_space
 import legion_go2_brightness
@@ -247,3 +248,41 @@ class Plugin:
 
     async def log_info(self, info):
         logging.info(info)
+
+    # ── Fan support (DKMS repair) ─────────────────────────────────────────────
+
+    async def get_fan_support_status(self):
+        """Returns 'ok', 'missing', or 'unknown' for the current kernel."""
+        return fan_support.get_fan_support_status()
+
+    async def get_current_kernel(self):
+        """Returns raw uname -r output for display in the UI."""
+        return fan_support.get_current_kernel()
+
+    async def apply_fan_fix(self):
+        """
+        Starts the DKMS repair sequence in a background thread.
+        Returns {"started": True} or {"started": False, "error": "<reason>"}.
+        Frontend should poll get_fan_fix_progress() immediately after.
+        """
+        return fan_support.apply_fan_fix()
+
+    async def get_fan_fix_progress(self):
+        """Returns current fix-worker progress for frontend polling."""
+        return fan_support.get_fan_fix_progress()
+
+    async def restart_decky(self):
+        """Restarts the Decky Loader process via pkill so systemd relaunches it."""
+        return fan_support.restart_decky()
+
+    async def reboot_device(self):
+        """Reboots the device immediately via systemctl reboot."""
+        return fan_support.reboot_device()
+
+    async def refresh_fan_support(self):
+        """
+        Re-checks whether acpi_call is loadable and returns True/False.
+        Called after a successful fix so the frontend can update
+        supportsCustomFanCurves in the Redux store without a full reload.
+        """
+        return settings.supports_custom_fan_curves()

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import asyncio
 import decky_plugin
 import ambient_light_sensor
 import fan_support
+import fan_watchdog
 import legion_configurator
 import legion_space
 import legion_go2_brightness
@@ -31,10 +32,59 @@ try:
 except Exception as e:
     logging.error(f"exception|{e}")
 
+# ── Fan watchdog state ────────────────────────────────────────────────────────
+
+_fan_cache = {
+    'custom_curves_enabled': False,
+    'fan_per_game_enabled': False,
+    'fan_profiles': {},
+    'current_game_id': 'default',
+    'last_curve': None,
+}
+
+
+def _get_active_fan_profile():
+    profiles = _fan_cache.get('fan_profiles', {})
+    if _fan_cache.get('fan_per_game_enabled'):
+        game_id = _fan_cache.get('current_game_id', 'default')
+        return profiles.get(game_id) or profiles.get('default')
+    return profiles.get('default')
+
+
+def _get_active_profile_threshold():
+    profile = _get_active_fan_profile()
+    if not profile:
+        return None
+    threshold = profile.get('fullFanSpeedThreshold')
+    return int(threshold) if threshold is not None else None
+
+
+def _is_full_fan_always_on():
+    if not _fan_cache.get('custom_curves_enabled'):
+        return True
+    profile = _get_active_fan_profile()
+    return bool(profile.get('fullFanSpeedEnabled', False)) if profile else True
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
 class Plugin:
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
         decky_plugin.logger.info("Hello World!")
+
+        s = settings.get_settings()
+        _fan_cache['custom_curves_enabled'] = bool(s.get('customFanCurvesEnabled', False))
+        _fan_cache['fan_per_game_enabled'] = bool(s.get('fanPerGameProfilesEnabled', False))
+        _fan_cache['fan_profiles'] = s.get('fan', {})
+
+        self._watchdog = fan_watchdog.FanWatchdog(
+            legion_space=legion_space,
+            get_last_curve=lambda: _fan_cache.get('last_curve'),
+            get_active_profile_threshold=_get_active_profile_threshold,
+            is_user_full_fan_always_on=_is_full_fan_always_on,
+        )
+        self._watchdog.start()
 
         if legion_go2_brightness.is_legion_go_2():
             decky_plugin.logger.info("Legion Go 2 detected, starting backlight watcher")
@@ -125,6 +175,11 @@ class Plugin:
         settings.set_setting('customFanCurvesEnabled', customFanCurvesEnabled)
         settings.set_all_fan_profiles(fanProfiles)
 
+        _fan_cache['custom_curves_enabled'] = customFanCurvesEnabled
+        _fan_cache['fan_per_game_enabled'] = fanPerGameProfilesEnabled
+        _fan_cache['fan_profiles'] = {k: dict(v) for k, v in fanProfiles.items()}
+        _fan_cache['current_game_id'] = currentGameId
+
         try:
             active_fan_profile = fanProfiles.get('default')
 
@@ -135,13 +190,19 @@ class Plugin:
                         active_fan_profile = fan_profile
 
                 enable_full_fan_speed = active_fan_profile.get("fullFanSpeedEnabled", False)
+                threshold = active_fan_profile.pop("fullFanSpeedThreshold", None)
                 del active_fan_profile['fullFanSpeedEnabled']
+                if not enable_full_fan_speed and threshold is not None:
+                    for k in active_fan_profile:
+                        if int(k) >= threshold:
+                            active_fan_profile[k] = 115
                 active_fan_curve = list(active_fan_profile.values())
 
                 if not enable_full_fan_speed:
                     legion_space.set_full_fan_speed(False)
                     sleep(0.5)
                     legion_space.set_active_fan_curve(active_fan_curve)
+                    _fan_cache['last_curve'] = active_fan_curve
                 else:
                     legion_space.set_full_fan_speed(True)
             elif not customFanCurvesEnabled and settings.supports_custom_fan_curves():
@@ -222,6 +283,8 @@ class Plugin:
     # Function called first during the unload process, utilize this to handle your plugin being removed
     async def _unload(self):
         decky_plugin.logger.info("Goodbye World!")
+        if hasattr(self, '_watchdog'):
+            self._watchdog.stop()
         legion_go2_brightness.stop_backlight_watcher()
         if hasattr(self, '_backlight_task'):
             self._backlight_task.cancel()

--- a/py_modules/fan_support.py
+++ b/py_modules/fan_support.py
@@ -1,0 +1,1 @@
+../submodules/LegionFanFix/py_modules/fan_support.py

--- a/py_modules/fan_support.py
+++ b/py_modules/fan_support.py
@@ -1,1 +1,333 @@
-../submodules/LegionFanFix/py_modules/fan_support.py
+"""
+fan_support — DKMS/ACPI fan-fix backend.
+
+Shared between LegionFanFix and LegionGoRemapper (consumed via git submodule
+in LGR). Fixes belong here first; LGR bumps its submodule pin to pick them up.
+
+Uses decky_plugin.logger (available in both plugins' execution context).
+Returns plain Python types; plugin.py wraps them in _ok/_err envelopes as needed.
+"""
+
+import os
+import subprocess
+import threading
+
+import decky_plugin
+
+# ── Progress state ─────────────────────────────────────────────────────────────
+
+_progress_lock = threading.Lock()
+_progress_state: dict = {
+    "step":            "",     # human-readable current step
+    "running":         False,  # True while worker thread is active
+    "done":            False,  # True once finished (success or error)
+    "success":         None,   # True | False | None
+    "error":           "",     # error message when success is False
+    "reboot_required": False,  # True when modprobe failed (module needs reboot to load)
+}
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def _run(cmd: list, timeout: int = 60) -> tuple:
+    """
+    Run a subprocess, returning (returncode, stdout, stderr).
+    Never raises — all exceptions surface as rc=-1.
+    Strips Homebrew library paths so system binaries don't pick up the wrong libs.
+    """
+    decky_plugin.logger.debug("fan_support: run %s", " ".join(cmd))
+    try:
+        env = os.environ.copy()
+        for var in ("LD_LIBRARY_PATH", "LD_PRELOAD", "DYLD_LIBRARY_PATH"):
+            env.pop(var, None)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+        decky_plugin.logger.debug(
+            "fan_support: rc=%d stdout=%r", result.returncode, result.stdout[:200]
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        msg = f"Command timed out after {timeout}s: {' '.join(cmd)}"
+        decky_plugin.logger.error("fan_support: %s", msg)
+        return -1, "", msg
+    except Exception as exc:
+        decky_plugin.logger.error("fan_support: unexpected error running %s: %s", cmd, exc)
+        return -1, "", str(exc)
+
+
+def _set_progress(step: str) -> None:
+    with _progress_lock:
+        _progress_state["step"] = step
+    decky_plugin.logger.info("fan_support: %s", step)
+
+
+def _get_current_kernel() -> str:
+    """Return raw `uname -r` output, e.g. '6.11.11-valve24'."""
+    rc, stdout, _ = _run(["uname", "-r"])
+    return stdout if rc == 0 else ""
+
+
+def _is_kernel_supported(kernel: str):
+    """
+    Check whether acpi_call DKMS is built and active for the given kernel string.
+
+    Returns:
+        True  — acpi_call is installed for this kernel
+        False — acpi_call entry absent or not built (fix is needed)
+        None  — could not determine (dkms not installed, parse error, etc.)
+    """
+    if not kernel:
+        return None
+
+    rc, stdout, _ = _run(["dkms", "status"])
+    if rc != 0:
+        # dkms not installed or never set up — fix is needed either way
+        return False
+
+    # dkms status lines look like:
+    #   acpi_call/1.2.2, 6.11.11-valve24, x86_64: installed
+    for line in stdout.splitlines():
+        if "acpi_call" in line and kernel in line:
+            return "installed" in line.lower()
+
+    return False  # acpi_call entry not found for this kernel
+
+
+# ── Background worker ──────────────────────────────────────────────────────────
+
+def _apply_fan_fix_worker() -> None:
+    """
+    7-step DKMS repair sequence that runs in a daemon thread.
+    Frontend polls get_fan_fix_progress() while this runs.
+    """
+    with _progress_lock:
+        _progress_state.update({"running": True, "done": False, "success": None, "error": ""})
+
+    try:
+        kernel = _get_current_kernel()
+        if not kernel:
+            raise RuntimeError("Could not determine current kernel version.")
+
+        # ── Step 1: Disable read-only filesystem ──────────────────────────────
+        _set_progress("Disabling read-only filesystem\u2026")
+        rc, _, stderr = _run(["steamos-readonly", "disable"], timeout=30)
+        if rc != 0:
+            raise RuntimeError(f"steamos-readonly disable failed: {stderr}")
+
+        # ── Step 2: Initialize pacman keyring (if not already done) ──────────
+        # On SteamOS the pacman keyring is sometimes absent or non-writable,
+        # causing all subsequent pacman installs to fail with
+        # "Public keyring not found" / "keyring is not writable".
+        # Run pacman-key init+populate as a best-effort guard; failures are
+        # logged as warnings rather than aborting the sequence, because the
+        # keyring may already be initialised and the commands become no-ops.
+        _set_progress("Initializing pacman keyring\u2026")
+        rc_ki, _, stderr_ki = _run(["pacman-key", "--init"], timeout=120)
+        if rc_ki != 0:
+            decky_plugin.logger.warning(
+                "fan_support: pacman-key --init returned %d: %s", rc_ki, stderr_ki
+            )
+        # Populate both the standard Arch keyring and Valve's Holo (SteamOS)
+        # keyring so that SteamOS packages signed by ci-package-builder-1@steamos.cloud
+        # are trusted.
+        rc_kp, _, stderr_kp = _run(
+            ["pacman-key", "--populate", "archlinux", "holo"], timeout=60
+        )
+        if rc_kp != 0:
+            decky_plugin.logger.warning(
+                "fan_support: pacman-key --populate returned %d: %s", rc_kp, stderr_kp
+            )
+
+        # ── Step 3: Install kernel headers ────────────────────────────────────
+        # Valve publishes per-series headers packages: linux-neptune-611-headers
+        # for 6.11.x, linux-neptune-68-headers for 6.8.x, etc.
+        # Derive the series suffix from the running kernel's major.minor and try
+        # that package first before falling back to the legacy linux-neptune-headers
+        # (which is stuck at 5.13 and never matches modern SteamOS kernels).
+        _set_progress(f"Installing kernel headers for {kernel}\u2026")
+        try:
+            parts = kernel.split(".")
+            series = parts[0] + parts[1]   # "6" + "11" → "611"
+            versioned_pkg = f"linux-neptune-{series}-headers"
+        except (IndexError, ValueError):
+            versioned_pkg = None
+
+        rc = 1
+        if versioned_pkg:
+            rc, _, stderr = _run(
+                ["pacman", "-S", "--noconfirm", versioned_pkg],
+                timeout=180,
+            )
+        if rc != 0:
+            _set_progress("Trying generic linux-neptune-headers\u2026")
+            rc, _, stderr = _run(
+                ["pacman", "-S", "--noconfirm", "linux-neptune-headers"],
+                timeout=180,
+            )
+        if rc != 0:
+            raise RuntimeError(f"Kernel headers install failed: {stderr}")
+
+        # ── Step 4: Install DKMS + acpi_call-dkms ─────────────────────────────
+        _set_progress("Installing dkms and acpi_call-dkms\u2026")
+        rc, _, stderr = _run(
+            ["pacman", "-S", "--noconfirm", "dkms", "acpi_call-dkms"],
+            timeout=180,
+        )
+        if rc != 0:
+            raise RuntimeError(f"DKMS package install failed: {stderr}")
+
+        # ── Step 5: Build the DKMS module if pacman hooks didn't do it ────────
+        # pacman's post-install hook usually builds the module automatically.
+        # Only run dkms install manually if it didn't (e.g. kernel mismatch).
+        if not _is_kernel_supported(kernel):
+            _set_progress(f"Building acpi_call module for {kernel}\u2026")
+            rc_v, ver_out, _ = _run(["pacman", "-Q", "acpi_call-dkms"], timeout=10)
+            if rc_v != 0 or not ver_out:
+                raise RuntimeError("Could not determine acpi_call-dkms version from pacman.")
+            # "acpi_call-dkms 1.2.2-2" → "1.2.2"
+            acpi_version = ver_out.split()[1].split("-")[0]
+
+            build_path = f"/usr/lib/modules/{kernel}/build"
+            if not os.path.exists(build_path):
+                # Headers were installed for a different kernel version.
+                # This happens when SteamOS has a pending update — the new
+                # kernel's headers are installed but the old kernel is still
+                # running.  Building against mismatched headers causes a
+                # compilation failure, so skip the build and ask the user to
+                # reboot.  The packages are installed; DKMS will build the
+                # module correctly after rebooting into the new kernel.
+                _set_progress("Fan support installed \u2014 reboot required to activate.")
+                decky_plugin.logger.warning(
+                    "fan_support: headers mismatch for %s; marking reboot required", kernel
+                )
+                _run(["steamos-readonly", "enable"], timeout=30)
+                with _progress_lock:
+                    _progress_state.update({
+                        "running": False, "done": True, "success": True,
+                        "reboot_required": True,
+                    })
+                return
+
+            rc, _, stderr = _run(
+                ["dkms", "install", f"acpi_call/{acpi_version}", "-k", kernel],
+                timeout=300,
+            )
+            if rc != 0:
+                raise RuntimeError(f"dkms install failed: {stderr}")
+        else:
+            _set_progress("DKMS module already built by package install.")
+
+        # ── Step 6: Re-enable read-only filesystem ────────────────────────────
+        _set_progress("Re-enabling read-only filesystem\u2026")
+        _run(["steamos-readonly", "enable"], timeout=30)
+        # Non-fatal if this fails — keep going.
+
+        # ── Step 7: Load the module immediately (no reboot required) ──────────
+        _set_progress("Loading acpi_call kernel module\u2026")
+        rc_mp, _, _ = _run(["/usr/bin/modprobe", "acpi_call"], timeout=10)
+        reboot_required = rc_mp != 0
+        if reboot_required:
+            decky_plugin.logger.warning(
+                "fan_support: modprobe acpi_call failed (rc=%d); reboot required to activate",
+                rc_mp,
+            )
+
+        # ── Done ──────────────────────────────────────────────────────────────
+        _set_progress("Fan support installed successfully.")
+        with _progress_lock:
+            _progress_state.update({
+                "running": False, "done": True, "success": True,
+                "reboot_required": reboot_required,
+            })
+
+    except Exception as exc:
+        decky_plugin.logger.error("fan_support: worker failed: %s", exc)
+        # Best-effort: restore read-only fs even on failure.
+        _run(["steamos-readonly", "enable"], timeout=30)
+        _set_progress(f"Error: {exc}")
+        with _progress_lock:
+            _progress_state.update({
+                "running": False,
+                "done":    True,
+                "success": False,
+                "error":   str(exc),
+            })
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+def get_fan_support_status() -> str:
+    """
+    Returns 'ok', 'missing', or 'unknown'.
+    'ok'      — acpi_call is built and active for the current kernel
+    'missing' — acpi_call is absent or not built; fix is needed
+    'unknown' — could not determine (kernel unreadable, dkms error, etc.)
+    """
+    try:
+        kernel = _get_current_kernel()
+        if not kernel:
+            return "unknown"
+        supported = _is_kernel_supported(kernel)
+        if supported is True:
+            return "ok"
+        if supported is False:
+            return "missing"
+        return "unknown"
+    except Exception as exc:
+        decky_plugin.logger.error("fan_support: get_fan_support_status error: %s", exc)
+        return "unknown"
+
+
+def apply_fan_fix() -> dict:
+    """
+    Kicks off the repair sequence in a daemon thread.
+    Returns {"started": True} or {"started": False, "error": "<reason>"}.
+    Frontend should immediately start polling get_fan_fix_progress().
+    """
+    with _progress_lock:
+        if _progress_state["running"]:
+            return {"started": False, "error": "A fix is already in progress."}
+    thread = threading.Thread(target=_apply_fan_fix_worker, daemon=True)
+    thread.start()
+    return {"started": True, "error": ""}
+
+
+def get_fan_fix_progress() -> dict:
+    """
+    Returns a snapshot of the current fix progress state.
+    Frontend polls this every 2 s while running is True.
+    """
+    with _progress_lock:
+        return dict(_progress_state)
+
+
+def get_current_kernel() -> str:
+    """Returns raw `uname -r` output for display in the UI."""
+    return _get_current_kernel() or "unknown"
+
+
+def reboot_device() -> bool:
+    """Reboots the device immediately via systemctl reboot."""
+    rc, _, stderr = _run(["/usr/bin/systemctl", "reboot"], timeout=10)
+    if rc not in (0, 1):
+        decky_plugin.logger.error("fan_support: reboot_device failed: %s", stderr)
+        return False
+    return True
+
+
+def restart_decky() -> bool:
+    """
+    Kills the PluginLoader process so systemd restarts it, reloading all
+    plugins immediately.  pkill exit code 1 means no process matched, which
+    is treated as success (already restarting).
+    """
+    rc, _, stderr = _run(["/usr/bin/pkill", "-f", "PluginLoader"], timeout=5)
+    if rc not in (0, 1):
+        decky_plugin.logger.error("fan_support: restart_decky failed: %s", stderr)
+        return False
+    return True

--- a/py_modules/fan_watchdog.py
+++ b/py_modules/fan_watchdog.py
@@ -1,0 +1,165 @@
+"""
+Adaptive fan watchdog: monitors CPU/GPU temperature and temporarily pins
+fan speed to maximum when a configurable threshold is exceeded, then
+restores the active fan curve once temps drop back down.
+
+State machine: CURVE ↔ OVERRIDE
+  CURVE → OVERRIDE: temp ≥ engage_c for engage_streak consecutive samples
+  OVERRIDE → CURVE: temp < release_c for release_streak consecutive samples
+"""
+
+import glob
+import os
+import threading
+import time
+
+import decky_plugin
+
+
+def _find_hwmon_temp(driver_name: str, preferred: tuple) -> str | None:
+    for hwmon_dir in glob.glob('/sys/class/hwmon/hwmon*'):
+        try:
+            with open(os.path.join(hwmon_dir, 'name')) as f:
+                if f.read().strip() != driver_name:
+                    continue
+        except OSError:
+            continue
+        for inp in preferred:
+            path = os.path.join(hwmon_dir, inp)
+            if os.path.exists(path):
+                return path
+    return None
+
+
+def _read_temp_c(path: str) -> float | None:
+    try:
+        with open(path) as f:
+            return int(f.read().strip()) / 1000.0
+    except (OSError, ValueError):
+        return None
+
+
+class FanWatchdog:
+    def __init__(
+        self,
+        legion_space,
+        get_last_curve,
+        get_active_profile_threshold,
+        is_user_full_fan_always_on,
+        default_engage_c: float = 78.0,
+        default_release_c: float = 68.0,
+        engage_streak: int = 3,
+        release_streak: int = 10,
+        poll_hz: float = 2.0,
+    ):
+        self._legion_space = legion_space
+        self._get_last_curve = get_last_curve
+        self._get_active_profile_threshold = get_active_profile_threshold
+        self._is_user_full_fan_always_on = is_user_full_fan_always_on
+        self._default_engage_c = default_engage_c
+        self._default_release_c = default_release_c
+        self._engage_streak = engage_streak
+        self._release_streak = release_streak
+        self._interval = 1.0 / poll_hz
+
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._state = 'CURVE'
+        self._engage_count = 0
+        self._release_count = 0
+
+        self._cpu_temp_path: str | None = None
+        self._gpu_temp_path: str | None = None
+
+    def start(self):
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name='FanWatchdog')
+        self._thread.start()
+        decky_plugin.logger.info('[FanWatchdog] started')
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+        decky_plugin.logger.info('[FanWatchdog] stopped')
+
+    def _discover_temps(self):
+        self._cpu_temp_path = _find_hwmon_temp('k10temp', ('temp1_input',))
+        self._gpu_temp_path = _find_hwmon_temp('amdgpu', ('temp2_input', 'temp1_input'))
+        decky_plugin.logger.info(
+            f'[FanWatchdog] temp paths — cpu: {self._cpu_temp_path}, gpu: {self._gpu_temp_path}'
+        )
+
+    def _read_max_temp(self) -> float | None:
+        if not self._cpu_temp_path or not self._gpu_temp_path:
+            self._discover_temps()
+
+        cpu = _read_temp_c(self._cpu_temp_path) if self._cpu_temp_path else None
+        gpu = _read_temp_c(self._gpu_temp_path) if self._gpu_temp_path else None
+
+        # Force re-discover on read failure
+        if cpu is None and self._cpu_temp_path:
+            self._cpu_temp_path = None
+        if gpu is None and self._gpu_temp_path:
+            self._gpu_temp_path = None
+
+        temps = [t for t in (cpu, gpu) if t is not None]
+        return max(temps) if temps else None
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                self._tick()
+            except Exception as e:
+                decky_plugin.logger.error(f'[FanWatchdog] tick error: {e}')
+            self._stop_event.wait(self._interval)
+
+    def _tick(self):
+        if self._is_user_full_fan_always_on():
+            self._engage_count = 0
+            self._release_count = 0
+            return
+
+        threshold = self._get_active_profile_threshold()
+        if threshold is not None:
+            engage_c = float(threshold)
+            release_c = max(60.0, engage_c - 10.0)
+        else:
+            engage_c = self._default_engage_c
+            release_c = self._default_release_c
+
+        temp = self._read_max_temp()
+        if temp is None:
+            return
+
+        if self._state == 'CURVE':
+            if temp >= engage_c:
+                self._engage_count += 1
+                self._release_count = 0
+                if self._engage_count >= self._engage_streak:
+                    decky_plugin.logger.info(
+                        f'[FanWatchdog] OVERRIDE: {temp:.1f}°C >= {engage_c}°C'
+                    )
+                    self._state = 'OVERRIDE'
+                    self._engage_count = 0
+                    self._legion_space.set_full_fan_speed(True)
+            else:
+                self._engage_count = 0
+
+        elif self._state == 'OVERRIDE':
+            if temp < release_c:
+                self._release_count += 1
+                self._engage_count = 0
+                if self._release_count >= self._release_streak:
+                    decky_plugin.logger.info(
+                        f'[FanWatchdog] CURVE: {temp:.1f}°C < {release_c}°C'
+                    )
+                    self._state = 'CURVE'
+                    self._release_count = 0
+                    self._legion_space.set_full_fan_speed(False)
+                    time.sleep(0.3)
+                    curve = self._get_last_curve()
+                    if curve:
+                        self._legion_space.set_active_fan_curve(curve)
+            else:
+                self._release_count = 0

--- a/py_modules/fan_watchdog.py
+++ b/py_modules/fan_watchdog.py
@@ -121,12 +121,13 @@ class FanWatchdog:
             return
 
         threshold = self._get_active_profile_threshold()
-        if threshold is not None:
-            engage_c = float(threshold)
-            release_c = max(60.0, engage_c - 10.0)
-        else:
-            engage_c = self._default_engage_c
-            release_c = self._default_release_c
+        if threshold is None:
+            self._engage_count = 0
+            self._release_count = 0
+            return
+
+        engage_c = float(threshold)
+        release_c = max(60.0, engage_c - 10.0)
 
         temp = self._read_max_temp()
         if temp is None:
@@ -158,8 +159,10 @@ class FanWatchdog:
                     self._release_count = 0
                     self._legion_space.set_full_fan_speed(False)
                     time.sleep(0.3)
-                    curve = self._get_last_curve()
-                    if curve:
-                        self._legion_space.set_active_fan_curve(curve)
+                    # Re-check: user may have toggled manual full-speed on during the sleep
+                    if not self._is_user_full_fan_always_on():
+                        curve = self._get_last_curve()
+                        if curve:
+                            self._legion_space.set_active_fan_curve(curve)
             else:
                 self._release_count = 0

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default defineConfig({
     globals: {
       react: "SP_REACT",
       "react-dom": "SP_REACTDOM",
-      "decky-frontend-lib": "DFL"
+      "decky-frontend-lib": "DFL",
     },
     format: 'iife',
     exports: 'default',

--- a/src/components/fan/FanCurveSliders.tsx
+++ b/src/components/fan/FanCurveSliders.tsx
@@ -1,12 +1,13 @@
+import { Fragment, VFC, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fanSlice, selectActiveFanCurve } from '../../redux-modules/fanSlice';
+import { useFullFanSpeedThreshold } from '../../hooks/fan';
 import {
   PanelSection,
   PanelSectionRow,
   SliderField,
   ToggleField
 } from 'decky-frontend-lib';
-import { VFC, useState } from 'react';
 
 const DISABLE_KEY = 'legion-go-remapper-disable-fan-curve-limit';
 
@@ -25,45 +26,65 @@ const useDisableLimit = () => {
 
 const FanCurveSliders: VFC = () => {
   const activeFanCurve = useSelector(selectActiveFanCurve);
-
   const { disableLimits, setLimit } = useDisableLimit();
-
+  const { threshold, setThreshold } = useFullFanSpeedThreshold();
   const dispatch = useDispatch();
 
-  const sliders = Object.entries(activeFanCurve).map(
-    ([temp, fanSpeed], idx) => {
-      const updateFanCurveValue = (temp: string, fanSpeed: number) => {
-        if (!disableLimits && idx >= 6 && fanSpeed < 70) {
-          fanSpeed = 70;
-        }
-        return dispatch(fanSlice.actions.updateFanCurve({ temp, fanSpeed }));
-      };
+  const sliders = Object.entries(activeFanCurve).map(([temp, fanSpeed], idx) => {
+    const tempNum = parseInt(temp);
+
+    if (threshold !== null && tempNum > threshold) return null;
+
+    if (threshold !== null && tempNum === threshold) {
       return (
-        <>
-          <PanelSectionRow>
-            <SliderField
-              label={`${temp} \u2103`}
-              value={fanSpeed}
-              showValue
-              valueSuffix="%"
-              step={5}
-              min={5}
-              max={115}
-              validValues="range"
-              bottomSeparator="none"
-              key={idx}
-              onChange={(newSpeed) => {
-                return updateFanCurveValue(temp, newSpeed);
-              }}
-            />
-          </PanelSectionRow>
-        </>
+        <PanelSectionRow key={idx}>
+          <ToggleField
+            label={`\u2265 ${temp}\u2103 \u2014 Full speed`}
+            checked={true}
+            onChange={() => setThreshold(null)}
+          />
+        </PanelSectionRow>
       );
     }
-  );
+
+    const updateFanCurveValue = (t: string, speed: number) => {
+      if (!disableLimits && idx >= 6 && speed < 70) speed = 70;
+      return dispatch(fanSlice.actions.updateFanCurve({ temp: t, fanSpeed: speed }));
+    };
+
+    const showThresholdToggle = tempNum >= 70 && threshold === null;
+
+    return (
+      <Fragment key={idx}>
+        <PanelSectionRow>
+          <SliderField
+            label={`${temp} \u2103`}
+            value={fanSpeed}
+            showValue
+            valueSuffix="%"
+            step={5}
+            min={5}
+            max={115}
+            validValues="range"
+            bottomSeparator="none"
+            onChange={(newSpeed) => updateFanCurveValue(temp, newSpeed)}
+          />
+        </PanelSectionRow>
+        {showThresholdToggle && (
+          <PanelSectionRow>
+            <ToggleField
+              label={`Full speed \u2265 ${temp}\u2103`}
+              checked={false}
+              onChange={() => setThreshold(tempNum)}
+            />
+          </PanelSectionRow>
+        )}
+      </Fragment>
+    );
+  });
 
   return (
-    <PanelSection title={'Temp (\u2103) | Fan Speed (%)'}>
+    <PanelSection title={'\u2103 | Fan Speed (%)'}>
       <PanelSectionRow>
         <ToggleField
           label="Disable Fan Curve Limits"

--- a/src/components/fan/FanCurveSliders.tsx
+++ b/src/components/fan/FanCurveSliders.tsx
@@ -52,7 +52,7 @@ const FanCurveSliders: VFC = () => {
       return dispatch(fanSlice.actions.updateFanCurve({ temp: t, fanSpeed: speed }));
     };
 
-    const showThresholdToggle = tempNum >= 70 && threshold === null;
+    const showThresholdToggle = tempNum >= 60 && threshold === null;
 
     return (
       <Fragment key={idx}>

--- a/src/components/fan/FanFixFlow.tsx
+++ b/src/components/fan/FanFixFlow.tsx
@@ -1,0 +1,86 @@
+import { PanelSectionRow } from 'decky-frontend-lib';
+import { VFC } from 'react';
+import { FaFan } from 'react-icons/fa';
+import { FanFixPhase } from '../../hooks/fan';
+
+interface FanFixFlowProps {
+  phase: FanFixPhase;
+  progressStep: string;
+  errorMsg: string;
+}
+
+/**
+ * Shared inline content for the fan-fix apply flow.
+ * Renders nothing when idle; renders a progress row while fixing,
+ * and a result banner on success or error.
+ * Embedded by both FanSupportRepair (full-takeover) and FanSupportFooter
+ * (compact) so the treatment is consistent.
+ */
+const FanFixFlow: VFC<FanFixFlowProps> = ({ phase, progressStep, errorMsg }) => {
+  if (phase === 'idle') return null;
+
+  return (
+    <>
+      {phase === 'fixing' && (
+        <PanelSectionRow>
+          <style>{`
+            @keyframes lgrFanSpin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }
+          `}</style>
+          <div style={{
+            display: 'flex', alignItems: 'flex-start', gap: '10px',
+            padding: '10px 12px', width: '100%', boxSizing: 'border-box',
+            background: 'rgba(200,168,75,0.06)',
+            border: '1px solid rgba(200,168,75,0.2)', borderRadius: '4px',
+          }}>
+            <FaFan style={{
+              marginTop: '2px', flexShrink: 0,
+              color: '#c8a84b',
+              animation: 'lgrFanSpin 1.5s linear infinite',
+            }} />
+            <div>
+              <div style={{
+                fontSize: '11px', fontWeight: 700, letterSpacing: '0.08em',
+                color: '#c8a84b', marginBottom: '3px', textTransform: 'uppercase',
+              }}>
+                Applying Fix…
+              </div>
+              <div style={{ fontSize: '12px', color: '#a09070', lineHeight: 1.5 }}>
+                {progressStep || 'Starting…'}
+              </div>
+            </div>
+          </div>
+        </PanelSectionRow>
+      )}
+
+      {phase === 'success' && (
+        <PanelSectionRow>
+          <div style={{
+            padding: '8px 12px', width: '100%', boxSizing: 'border-box',
+            background: 'rgba(76,175,110,0.1)',
+            border: '1px solid rgba(76,175,110,0.3)', borderRadius: '4px',
+            fontSize: '12px', color: '#4caf6e', lineHeight: 1.5,
+          }}>
+            &#10003; Fan support restored. Restart Decky or your device to
+            activate fan controls.
+          </div>
+        </PanelSectionRow>
+      )}
+
+      {phase === 'error' && (
+        <PanelSectionRow>
+          <div style={{
+            padding: '8px 12px', width: '100%', boxSizing: 'border-box',
+            background: 'rgba(232,64,64,0.08)',
+            border: '1px solid rgba(232,64,64,0.25)', borderRadius: '4px',
+            fontSize: '12px', color: '#e06060', lineHeight: 1.5,
+            wordBreak: 'break-word',
+          }}>
+            &#10007; {errorMsg || 'An unknown error occurred.'}
+          </div>
+        </PanelSectionRow>
+      )}
+    </>
+  );
+};
+
+export default FanFixFlow;

--- a/src/components/fan/FanFixFlow.tsx
+++ b/src/components/fan/FanFixFlow.tsx
@@ -9,13 +9,6 @@ interface FanFixFlowProps {
   errorMsg: string;
 }
 
-/**
- * Shared inline content for the fan-fix apply flow.
- * Renders nothing when idle; renders a progress row while fixing,
- * and a result banner on success or error.
- * Embedded by both FanSupportRepair (full-takeover) and FanSupportFooter
- * (compact) so the treatment is consistent.
- */
 const FanFixFlow: VFC<FanFixFlowProps> = ({ phase, progressStep, errorMsg }) => {
   if (phase === 'idle') return null;
 
@@ -60,8 +53,7 @@ const FanFixFlow: VFC<FanFixFlowProps> = ({ phase, progressStep, errorMsg }) => 
             border: '1px solid rgba(76,175,110,0.3)', borderRadius: '4px',
             fontSize: '12px', color: '#4caf6e', lineHeight: 1.5,
           }}>
-            &#10003; Fan support restored. Restart Decky or your device to
-            activate fan controls.
+            &#10003; Fan support restored. Restart Decky or your device to activate fan controls.
           </div>
         </PanelSectionRow>
       )}

--- a/src/components/fan/FanPanel.tsx
+++ b/src/components/fan/FanPanel.tsx
@@ -5,6 +5,7 @@ import {
   ToggleField
 } from 'decky-frontend-lib';
 import {
+  FanFixFlowState,
   useCustomFanCurvesEnabled,
   useEnableFullFanSpeedMode,
   useFanPerGameProfilesEnabled,
@@ -12,9 +13,10 @@ import {
 } from '../../hooks/fan';
 import { capitalize } from 'lodash';
 import { useSelector } from 'react-redux';
-import { useState } from 'react';
+import { useState, VFC } from 'react';
 import { selectCurrentGameDisplayName } from '../../redux-modules/uiSlice';
 import FanCurveSliders from './FanCurveSliders';
+import FanSupportRepair from './FanSupportRepair';
 import { IoMdArrowDropdown, IoMdArrowDropup } from 'react-icons/io';
 
 const useTitle = (fanPerGameProfilesEnabled: boolean) => {
@@ -31,7 +33,11 @@ const useTitle = (fanPerGameProfilesEnabled: boolean) => {
 
 const WARNING_KEY = 'legionGoRemapper.customfan.warning';
 
-const FanPanel = () => {
+interface FanPanelProps {
+  fixFlow: FanFixFlowState;
+}
+
+const FanPanel: VFC<FanPanelProps> = ({ fixFlow }) => {
   const supportsFanCurves = useSupportsCustomFanCurves();
   const [showSliders, setShowSliders] = useState(false);
   const [acknowledgeWarning, setAcknowledgeWarning] = useState(
@@ -52,7 +58,7 @@ const FanPanel = () => {
   const title = useTitle(fanPerGameProfilesEnabled);
 
   if (!supportsFanCurves) {
-    return null;
+    return <FanSupportRepair fixFlow={fixFlow} />;
   }
 
   return (

--- a/src/components/fan/FanPanel.tsx
+++ b/src/components/fan/FanPanel.tsx
@@ -34,7 +34,7 @@ const useTitle = (fanPerGameProfilesEnabled: boolean) => {
 const WARNING_KEY = 'legionGoRemapper.customfan.warning';
 
 interface FanPanelProps {
-  fixFlow: FanFixFlowState;
+  fixFlow: FanFixFlowState | null;
 }
 
 const FanPanel: VFC<FanPanelProps> = ({ fixFlow }) => {
@@ -57,7 +57,7 @@ const FanPanel: VFC<FanPanelProps> = ({ fixFlow }) => {
     useFanPerGameProfilesEnabled();
   const title = useTitle(fanPerGameProfilesEnabled);
 
-  if (!supportsFanCurves) {
+  if (!supportsFanCurves && fixFlow) {
     return <FanSupportRepair fixFlow={fixFlow} />;
   }
 

--- a/src/components/fan/FanRestartModal.tsx
+++ b/src/components/fan/FanRestartModal.tsx
@@ -1,0 +1,124 @@
+import { ModalRoot } from 'decky-frontend-lib';
+import { useState, VFC } from 'react';
+import { FaFan } from 'react-icons/fa';
+import { getServerApi } from '../../backend/utils';
+
+interface FanRestartModalProps {
+  closeModal?: () => void;
+  rebootRequired?: boolean;
+}
+
+/**
+ * Shown after a successful fan-fix.
+ * When rebootRequired is false (modprobe loaded the module live), offers an
+ * immediate Decky restart — buttons are replaced by a spinning fan while
+ * the process is killed.
+ * When rebootRequired is true (modprobe failed, e.g. mismatched kernel headers
+ * from a pending SteamOS update), tells the user to reboot instead; a Decky
+ * restart alone won't help because the module isn't loaded yet.
+ */
+const FanRestartModal: VFC<FanRestartModalProps> = ({ closeModal, rebootRequired = false }) => {
+  const [restarting, setRestarting] = useState(false);
+
+  return (
+    <ModalRoot closeModal={closeModal}>
+      <style>{`
+        @keyframes lgrRestartSpin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }
+      `}</style>
+      <div style={{ fontSize: '17px', fontWeight: 700, marginBottom: '12px', color: '#fff' }}>
+        {rebootRequired ? 'Reboot Required' : 'Restart Decky?'}
+      </div>
+      <div style={{ fontSize: '13px', color: '#a09070', lineHeight: 1.6, marginBottom: '24px' }}>
+        {rebootRequired
+          ? 'Fan support has been installed. The kernel module could not be loaded immediately — this usually means SteamOS has a pending update. Reboot your device to activate fan controls.'
+          : 'Fan support has been restored. Restart Decky to activate fan controls in LegionGoRemapper immediately, or reboot your device at any time.'}
+      </div>
+
+      {rebootRequired ? restarting ? (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          gap: '10px', padding: '10px 0',
+        }}>
+          <FaFan style={{
+            color: '#c8a84b', fontSize: '18px',
+            animation: 'lgrRestartSpin 1.5s linear infinite',
+          }} />
+          <span style={{
+            color: '#c8a84b', fontSize: '13px', fontWeight: 600, letterSpacing: '0.05em',
+          }}>
+            Rebooting…
+          </span>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={() => closeModal?.()}
+            style={{
+              padding: '8px 18px', cursor: 'pointer', fontSize: '13px',
+              background: 'rgba(255,255,255,0.08)', color: '#aaa',
+              border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+            }}
+          >
+            Later
+          </button>
+          <button
+            onClick={() => {
+              setRestarting(true);
+              setTimeout(() => getServerApi()?.callPluginMethod('reboot_device', {}), 300);
+            }}
+            style={{
+              padding: '8px 18px', cursor: 'pointer', fontSize: '13px', fontWeight: 600,
+              background: 'rgba(200,168,75,0.25)', color: '#c8a84b',
+              border: '1px solid rgba(200,168,75,0.5)', borderRadius: '4px',
+            }}
+          >
+            Reboot Now
+          </button>
+        </div>
+      ) : restarting ? (
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          gap: '10px', padding: '10px 0',
+        }}>
+          <FaFan style={{
+            color: '#c8a84b', fontSize: '18px',
+            animation: 'lgrRestartSpin 1.5s linear infinite',
+          }} />
+          <span style={{
+            color: '#c8a84b', fontSize: '13px', fontWeight: 600, letterSpacing: '0.05em',
+          }}>
+            Restarting Decky…
+          </span>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={() => closeModal?.()}
+            style={{
+              padding: '8px 18px', cursor: 'pointer', fontSize: '13px',
+              background: 'rgba(255,255,255,0.08)', color: '#aaa',
+              border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
+            }}
+          >
+            Later
+          </button>
+          <button
+            onClick={() => {
+              setRestarting(true);
+              setTimeout(() => getServerApi()?.callPluginMethod('restart_decky', {}), 300);
+            }}
+            style={{
+              padding: '8px 18px', cursor: 'pointer', fontSize: '13px', fontWeight: 600,
+              background: 'rgba(200,168,75,0.25)', color: '#c8a84b',
+              border: '1px solid rgba(200,168,75,0.5)', borderRadius: '4px',
+            }}
+          >
+            Restart Decky
+          </button>
+        </div>
+      )}
+    </ModalRoot>
+  );
+};
+
+export default FanRestartModal;

--- a/src/components/fan/FanRestartModal.tsx
+++ b/src/components/fan/FanRestartModal.tsx
@@ -8,17 +8,14 @@ interface FanRestartModalProps {
   rebootRequired?: boolean;
 }
 
-/**
- * Shown after a successful fan-fix.
- * When rebootRequired is false (modprobe loaded the module live), offers an
- * immediate Decky restart — buttons are replaced by a spinning fan while
- * the process is killed.
- * When rebootRequired is true (modprobe failed, e.g. mismatched kernel headers
- * from a pending SteamOS update), tells the user to reboot instead; a Decky
- * restart alone won't help because the module isn't loaded yet.
- */
 const FanRestartModal: VFC<FanRestartModalProps> = ({ closeModal, rebootRequired = false }) => {
   const [restarting, setRestarting] = useState(false);
+
+  const handleAction = () => {
+    setRestarting(true);
+    const method = rebootRequired ? 'reboot_device' : 'restart_decky';
+    setTimeout(() => getServerApi()?.callPluginMethod(method, {}), 300);
+  };
 
   return (
     <ModalRoot closeModal={closeModal}>
@@ -31,10 +28,10 @@ const FanRestartModal: VFC<FanRestartModalProps> = ({ closeModal, rebootRequired
       <div style={{ fontSize: '13px', color: '#a09070', lineHeight: 1.6, marginBottom: '24px' }}>
         {rebootRequired
           ? 'Fan support has been installed. The kernel module could not be loaded immediately — this usually means SteamOS has a pending update. Reboot your device to activate fan controls.'
-          : 'Fan support has been restored. Restart Decky to activate fan controls in LegionGoRemapper immediately, or reboot your device at any time.'}
+          : 'Fan support has been restored. Restart Decky to activate fan controls immediately, or reboot your device at any time.'}
       </div>
 
-      {rebootRequired ? restarting ? (
+      {restarting ? (
         <div style={{
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           gap: '10px', padding: '10px 0',
@@ -46,7 +43,7 @@ const FanRestartModal: VFC<FanRestartModalProps> = ({ closeModal, rebootRequired
           <span style={{
             color: '#c8a84b', fontSize: '13px', fontWeight: 600, letterSpacing: '0.05em',
           }}>
-            Rebooting…
+            {rebootRequired ? 'Rebooting…' : 'Restarting Decky…'}
           </span>
         </div>
       ) : (
@@ -62,58 +59,14 @@ const FanRestartModal: VFC<FanRestartModalProps> = ({ closeModal, rebootRequired
             Later
           </button>
           <button
-            onClick={() => {
-              setRestarting(true);
-              setTimeout(() => getServerApi()?.callPluginMethod('reboot_device', {}), 300);
-            }}
+            onClick={handleAction}
             style={{
               padding: '8px 18px', cursor: 'pointer', fontSize: '13px', fontWeight: 600,
               background: 'rgba(200,168,75,0.25)', color: '#c8a84b',
               border: '1px solid rgba(200,168,75,0.5)', borderRadius: '4px',
             }}
           >
-            Reboot Now
-          </button>
-        </div>
-      ) : restarting ? (
-        <div style={{
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          gap: '10px', padding: '10px 0',
-        }}>
-          <FaFan style={{
-            color: '#c8a84b', fontSize: '18px',
-            animation: 'lgrRestartSpin 1.5s linear infinite',
-          }} />
-          <span style={{
-            color: '#c8a84b', fontSize: '13px', fontWeight: 600, letterSpacing: '0.05em',
-          }}>
-            Restarting Decky…
-          </span>
-        </div>
-      ) : (
-        <div style={{ display: 'flex', gap: '10px', justifyContent: 'flex-end' }}>
-          <button
-            onClick={() => closeModal?.()}
-            style={{
-              padding: '8px 18px', cursor: 'pointer', fontSize: '13px',
-              background: 'rgba(255,255,255,0.08)', color: '#aaa',
-              border: '1px solid rgba(255,255,255,0.15)', borderRadius: '4px',
-            }}
-          >
-            Later
-          </button>
-          <button
-            onClick={() => {
-              setRestarting(true);
-              setTimeout(() => getServerApi()?.callPluginMethod('restart_decky', {}), 300);
-            }}
-            style={{
-              padding: '8px 18px', cursor: 'pointer', fontSize: '13px', fontWeight: 600,
-              background: 'rgba(200,168,75,0.25)', color: '#c8a84b',
-              border: '1px solid rgba(200,168,75,0.5)', borderRadius: '4px',
-            }}
-          >
-            Restart Decky
+            {rebootRequired ? 'Reboot Now' : 'Restart Decky'}
           </button>
         </div>
       )}

--- a/src/components/fan/FanStatusBadge.tsx
+++ b/src/components/fan/FanStatusBadge.tsx
@@ -1,0 +1,37 @@
+import { VFC } from 'react';
+
+export type BadgeStatus = 'ok' | 'missing' | 'checking';
+
+interface FanStatusBadgeProps {
+  status: BadgeStatus;
+}
+
+const configs: Record<BadgeStatus, { color: string; bg: string; border: string; dot: string; label: string }> = {
+  ok:       { color: '#4caf6e', bg: 'rgba(76,175,110,0.15)',  border: 'rgba(76,175,110,0.4)',  dot: '#4caf6e', label: 'ACTIVE' },
+  missing:  { color: '#e87040', bg: 'rgba(232,112,64,0.15)',  border: 'rgba(232,112,64,0.4)',  dot: '#e87040', label: 'NOT ACTIVE' },
+  checking: { color: '#a09070', bg: 'rgba(160,144,112,0.1)',  border: 'rgba(160,144,112,0.3)', dot: '#a09070', label: 'CHECKING…' },
+};
+
+const FanStatusBadge: VFC<FanStatusBadgeProps> = ({ status }) => {
+  const c = configs[status];
+  return (
+    <>
+      <style>{`@keyframes lgrBadgePulse { 0%,100%{opacity:1} 50%{opacity:0.3} }`}</style>
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: '7px',
+        padding: '4px 10px', borderRadius: '4px',
+        background: c.bg, border: `1px solid ${c.border}`,
+        fontSize: '11px', fontWeight: 700, letterSpacing: '0.08em', color: c.color,
+      }}>
+        <span style={{
+          width: '7px', height: '7px', borderRadius: '50%', background: c.dot,
+          boxShadow: status === 'ok' ? `0 0 6px ${c.dot}` : undefined,
+          animation: status === 'checking' ? 'lgrBadgePulse 1.2s ease-in-out infinite' : undefined,
+        }} />
+        {c.label}
+      </div>
+    </>
+  );
+};
+
+export default FanStatusBadge;

--- a/src/components/fan/FanSupportFooter.tsx
+++ b/src/components/fan/FanSupportFooter.tsx
@@ -1,0 +1,59 @@
+import {
+  ButtonItem,
+  PanelSection,
+  PanelSectionRow,
+} from 'decky-frontend-lib';
+import { VFC } from 'react';
+import { FanFixFlowState } from '../../hooks/fan';
+import FanFixFlow from './FanFixFlow';
+
+interface FanSupportFooterProps {
+  fixFlow: FanFixFlowState;
+}
+
+/**
+ * Compact footer appended below normal fan curve sliders when
+ * supportsCustomFanCurves is true.  Surfaces fan-support health at a glance
+ * and lets the user re-check or reapply the fix without navigating away.
+ */
+const FanSupportFooter: VFC<FanSupportFooterProps> = ({ fixFlow }) => {
+  const { phase, progressStep, errorMsg, checkingSupport, onApplyFix, onCheckAgain } = fixFlow;
+  const isFixing = phase === 'fixing';
+
+  return (
+    <PanelSection title="Fan Support">
+      <PanelSectionRow>
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          width: '100%', boxSizing: 'border-box',
+        }}>
+          <span style={{ fontSize: '12px', color: '#4caf6e' }}>
+            &#10003; Fan support: OK
+          </span>
+          <span
+            style={{
+              fontSize: '11px',
+              color: checkingSupport ? '#6a7a8a' : '#8a9ab0',
+              cursor: checkingSupport ? 'default' : 'pointer',
+              textDecoration: checkingSupport ? 'none' : 'underline',
+              textUnderlineOffset: '3px',
+            }}
+            onClick={checkingSupport ? undefined : onCheckAgain}
+          >
+            {checkingSupport ? 'Checking…' : 'Check again'}
+          </span>
+        </div>
+      </PanelSectionRow>
+
+      <FanFixFlow phase={phase} progressStep={progressStep} errorMsg={errorMsg} />
+
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={onApplyFix} disabled={isFixing || checkingSupport}>
+          {isFixing ? 'Applying Fix…' : 'Reapply fix'}
+        </ButtonItem>
+      </PanelSectionRow>
+    </PanelSection>
+  );
+};
+
+export default FanSupportFooter;

--- a/src/components/fan/FanSupportFooter.tsx
+++ b/src/components/fan/FanSupportFooter.tsx
@@ -4,20 +4,16 @@ import {
   PanelSectionRow,
 } from 'decky-frontend-lib';
 import { VFC } from 'react';
-import { FanFixFlowState } from '../../hooks/fan';
+import { FanFixFlowState, timeSince } from '../../hooks/fan';
 import FanFixFlow from './FanFixFlow';
+import FanStatusBadge from './FanStatusBadge';
 
 interface FanSupportFooterProps {
   fixFlow: FanFixFlowState;
 }
 
-/**
- * Compact footer appended below normal fan curve sliders when
- * supportsCustomFanCurves is true.  Surfaces fan-support health at a glance
- * and lets the user re-check or reapply the fix without navigating away.
- */
 const FanSupportFooter: VFC<FanSupportFooterProps> = ({ fixFlow }) => {
-  const { phase, progressStep, errorMsg, checkingSupport, onApplyFix, onCheckAgain } = fixFlow;
+  const { phase, progressStep, errorMsg, checkingSupport, lastChecked, onApplyFix, onCheckAgain } = fixFlow;
   const isFixing = phase === 'fixing';
 
   return (
@@ -27,9 +23,7 @@ const FanSupportFooter: VFC<FanSupportFooterProps> = ({ fixFlow }) => {
           display: 'flex', alignItems: 'center', justifyContent: 'space-between',
           width: '100%', boxSizing: 'border-box',
         }}>
-          <span style={{ fontSize: '12px', color: '#4caf6e' }}>
-            &#10003; Fan support: OK
-          </span>
+          <FanStatusBadge status={checkingSupport ? 'checking' : 'ok'} />
           <span
             style={{
               fontSize: '11px',
@@ -43,6 +37,11 @@ const FanSupportFooter: VFC<FanSupportFooterProps> = ({ fixFlow }) => {
             {checkingSupport ? 'Checking…' : 'Check again'}
           </span>
         </div>
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <span style={{ fontSize: '11px', color: '#6a5a40' }}>
+          Last checked: {timeSince(lastChecked)}
+        </span>
       </PanelSectionRow>
 
       <FanFixFlow phase={phase} progressStep={progressStep} errorMsg={errorMsg} />

--- a/src/components/fan/FanSupportRepair.tsx
+++ b/src/components/fan/FanSupportRepair.tsx
@@ -1,0 +1,54 @@
+import {
+  ButtonItem,
+  PanelSection,
+  PanelSectionRow,
+} from 'decky-frontend-lib';
+import { VFC } from 'react';
+import { FanFixFlowState, useCurrentKernel } from '../../hooks/fan';
+import FanFixFlow from './FanFixFlow';
+
+interface FanSupportRepairProps {
+  fixFlow: FanFixFlowState;
+}
+
+/**
+ * Full-takeover panel shown when supportsCustomFanCurves is false.
+ * Replaces the normal fan curve sliders with a repair prompt that includes
+ * the current kernel string for context.
+ */
+const FanSupportRepair: VFC<FanSupportRepairProps> = ({ fixFlow }) => {
+  const { phase, progressStep, errorMsg, onApplyFix } = fixFlow;
+  const kernel = useCurrentKernel();
+  const isFixing = phase === 'fixing';
+
+  return (
+    <PanelSection title="Fan Control">
+      <PanelSectionRow>
+        <div style={{
+          padding: '10px 12px', width: '100%', boxSizing: 'border-box',
+          background: 'rgba(232,112,64,0.08)',
+          border: '1px solid rgba(232,112,64,0.25)', borderRadius: '4px',
+          fontSize: '12px', color: '#c87050', lineHeight: 1.6,
+        }}>
+          <div>
+            &#9888; ACPI fan support is not active for the current kernel.
+            Custom fan curves will not respond until it is restored.
+          </div>
+          <div style={{ marginTop: '6px', fontFamily: 'monospace', fontSize: '11px', color: '#a08060' }}>
+            Kernel: {kernel}
+          </div>
+        </div>
+      </PanelSectionRow>
+
+      <FanFixFlow phase={phase} progressStep={progressStep} errorMsg={errorMsg} />
+
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={onApplyFix} disabled={isFixing}>
+          {isFixing ? 'Applying Fix…' : 'Apply Fan Fix'}
+        </ButtonItem>
+      </PanelSectionRow>
+    </PanelSection>
+  );
+};
+
+export default FanSupportRepair;

--- a/src/components/fan/FanSupportRepair.tsx
+++ b/src/components/fan/FanSupportRepair.tsx
@@ -6,6 +6,7 @@ import {
 import { VFC } from 'react';
 import { FanFixFlowState, useCurrentKernel } from '../../hooks/fan';
 import FanFixFlow from './FanFixFlow';
+import FanStatusBadge from './FanStatusBadge';
 
 interface FanSupportRepairProps {
   fixFlow: FanFixFlowState;
@@ -30,6 +31,9 @@ const FanSupportRepair: VFC<FanSupportRepairProps> = ({ fixFlow }) => {
           border: '1px solid rgba(232,112,64,0.25)', borderRadius: '4px',
           fontSize: '12px', color: '#c87050', lineHeight: 1.6,
         }}>
+          <div style={{ marginBottom: '8px' }}>
+            <FanStatusBadge status="missing" />
+          </div>
           <div>
             &#9888; ACPI fan support is not active for the current kernel.
             Custom fan curves will not respond until it is restored.

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -1,0 +1,9 @@
+/**
+ * Feature flags — set to false to disable a feature without removing its code.
+ *
+ * ENABLE_FAN_FIX: shows the ACPI fan support repair UI when the kernel module
+ * is missing, and a "Reapply Fix" footer when it is active. Requires the
+ * LegionFanFix backend (py_modules/fan_support.py + main.py fan fix methods).
+ * See testing/README.md for how to test this flow end-to-end.
+ */
+export const ENABLE_FAN_FIX = true;

--- a/src/hooks/fan.tsx
+++ b/src/hooks/fan.tsx
@@ -6,6 +6,7 @@ import {
   selectCustomFanCurvesEnabled,
   selectEnableFullFanSpeedMode,
   selectFanPerGameProfilesEnabled,
+  selectFullFanSpeedThreshold,
   selectSupportsCustomFanCurves
 } from '../redux-modules/fanSlice';
 import { getServerApi } from '../backend/utils';
@@ -191,6 +192,14 @@ export const useFanFixFlow = (): FanFixFlowState => {
   }, [startPolling, stopPolling]);
 
   return { phase, progressStep, errorMsg, checkingSupport, onApplyFix, onCheckAgain };
+};
+
+export const useFullFanSpeedThreshold = () => {
+  const threshold = useSelector(selectFullFanSpeedThreshold);
+  const dispatch = useDispatch();
+  const setThreshold = (value: number | null) =>
+    dispatch(fanSlice.actions.setFullFanSpeedThreshold(value));
+  return { threshold, setThreshold };
 };
 
 // ── Kernel string ──────────────────────────────────────────────────────────────

--- a/src/hooks/fan.tsx
+++ b/src/hooks/fan.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { ConfirmModal, showModal } from 'decky-frontend-lib';
 import {
   fanSlice,
   selectCustomFanCurvesEnabled,
@@ -6,6 +8,8 @@ import {
   selectFanPerGameProfilesEnabled,
   selectSupportsCustomFanCurves
 } from '../redux-modules/fanSlice';
+import { getServerApi } from '../backend/utils';
+import FanRestartModal from '../components/fan/FanRestartModal';
 
 export const useEnableFullFanSpeedMode = () => {
   const result = useSelector(selectEnableFullFanSpeedMode);
@@ -47,4 +51,162 @@ export const useFanPerGameProfilesEnabled = () => {
   };
 
   return { fanPerGameProfilesEnabled, setFanPerGameProfilesEnabled: setter };
+};
+
+// ── Fan fix flow ───────────────────────────────────────────────────────────────
+
+export type FanFixPhase = 'idle' | 'fixing' | 'success' | 'error';
+
+export interface FanFixFlowState {
+  phase: FanFixPhase;
+  progressStep: string;
+  errorMsg: string;
+  checkingSupport: boolean;
+  onApplyFix: () => void;
+  onCheckAgain: () => void;
+}
+
+interface FixProgressResult {
+  step: string;
+  running: boolean;
+  done: boolean;
+  success: boolean | null;
+  error: string;
+  reboot_required: boolean;
+}
+
+/**
+ * Encapsulates all fan-fix flow state and logic.
+ * Intended to be instantiated once in FanPanel so the state survives the
+ * FanSupportRepair → normal-sliders+FanSupportFooter transition after a fix.
+ */
+export const useFanFixFlow = (): FanFixFlowState => {
+  const [phase, setPhase] = useState<FanFixPhase>('idle');
+  const [progressStep, setProgressStep] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [checkingSupport, setCheckingSupport] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const dispatch = useDispatch();
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const refreshSupportState = useCallback(async () => {
+    const serverApi = getServerApi();
+    if (!serverApi) return;
+    const { result } = await serverApi.callPluginMethod('refresh_fan_support', {});
+    dispatch(fanSlice.actions.setSupportsCustomFanCurves(Boolean(result)));
+  }, [dispatch]);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      const serverApi = getServerApi();
+      if (!serverApi) return;
+      try {
+        const { result } = await serverApi.callPluginMethod('get_fan_fix_progress', {});
+        const prog = result as FixProgressResult;
+        if (!prog) return;
+        setProgressStep(prog.step);
+        if (prog.done) {
+          stopPolling();
+          if (prog.success) {
+            setPhase('success');
+            // Refresh supportsCustomFanCurves so FanPanel switches to normal view.
+            // Small delay lets the dkms module settle before the modprobe check.
+            setTimeout(refreshSupportState, 2000);
+            showModal(<FanRestartModal rebootRequired={prog.reboot_required} />);
+          } else {
+            setPhase('error');
+            setErrorMsg(prog.error || 'Unknown error.');
+          }
+        }
+      } catch {
+        // keep polling — transient RPC errors are expected
+      }
+    }, 2000);
+  }, [stopPolling, refreshSupportState]);
+
+  const onApplyFix = useCallback(() => {
+    showModal(
+      <ConfirmModal
+        strTitle="Apply Fan Fix?"
+        strDescription="This will temporarily disable the read-only filesystem and install kernel modules for ACPI fan control. The process takes 2–5 minutes. If SteamOS has a pending update, a device reboot may be required to activate fan control."
+        strOKButtonText="Apply Fix"
+        strCancelButtonText="Cancel"
+        onOK={async () => {
+          setPhase('fixing');
+          setProgressStep('Starting…');
+          setErrorMsg('');
+          const serverApi = getServerApi();
+          if (!serverApi) {
+            setPhase('error');
+            setErrorMsg('Plugin API unavailable.');
+            return;
+          }
+          try {
+            const { result } = await serverApi.callPluginMethod('apply_fan_fix', {});
+            const res = result as { started: boolean; error: string };
+            if (!res?.started) {
+              setPhase('error');
+              setErrorMsg(res?.error ?? 'Failed to start fix.');
+              return;
+            }
+            startPolling();
+          } catch (e) {
+            setPhase('error');
+            setErrorMsg(String(e));
+          }
+        }}
+      />
+    );
+  }, [startPolling]);
+
+  const onCheckAgain = useCallback(async () => {
+    setCheckingSupport(true);
+    await refreshSupportState();
+    setPhase('idle');
+    setProgressStep('');
+    setErrorMsg('');
+    setCheckingSupport(false);
+  }, [refreshSupportState]);
+
+  // On mount: resume polling if a fix was running when the panel was closed.
+  useEffect(() => {
+    const serverApi = getServerApi();
+    if (!serverApi) return;
+    serverApi.callPluginMethod('get_fan_fix_progress', {}).then(({ result }) => {
+      const prog = result as FixProgressResult;
+      if (prog?.running) {
+        setPhase('fixing');
+        setProgressStep(prog.step || 'Running…');
+        startPolling();
+      }
+    }).catch(() => {});
+    return stopPolling;
+  }, [startPolling, stopPolling]);
+
+  return { phase, progressStep, errorMsg, checkingSupport, onApplyFix, onCheckAgain };
+};
+
+// ── Kernel string ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the current kernel string (uname -r) once on mount.
+ * Used by FanSupportRepair to display context for the user during repair.
+ */
+export const useCurrentKernel = (): string => {
+  const [kernel, setKernel] = useState('…');
+  useEffect(() => {
+    const serverApi = getServerApi();
+    if (!serverApi) return;
+    serverApi.callPluginMethod('get_current_kernel', {}).then(({ result }) => {
+      if (result) setKernel(String(result));
+    }).catch(() => {});
+  }, []);
+  return kernel;
 };

--- a/src/hooks/fan.tsx
+++ b/src/hooks/fan.tsx
@@ -63,8 +63,17 @@ export interface FanFixFlowState {
   progressStep: string;
   errorMsg: string;
   checkingSupport: boolean;
+  lastChecked: number;
   onApplyFix: () => void;
   onCheckAgain: () => void;
+}
+
+export function timeSince(ts: number): string {
+  if (ts === 0) return 'never';
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} min ago`;
+  return `${Math.floor(seconds / 3600)} hr ago`;
 }
 
 interface FixProgressResult {
@@ -86,6 +95,7 @@ export const useFanFixFlow = (): FanFixFlowState => {
   const [progressStep, setProgressStep] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [checkingSupport, setCheckingSupport] = useState(false);
+  const [lastChecked, setLastChecked] = useState(0);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const dispatch = useDispatch();
 
@@ -173,25 +183,37 @@ export const useFanFixFlow = (): FanFixFlowState => {
     setPhase('idle');
     setProgressStep('');
     setErrorMsg('');
+    setLastChecked(Date.now());
     setCheckingSupport(false);
   }, [refreshSupportState]);
 
-  // On mount: resume polling if a fix was running when the panel was closed.
+  // On mount: resume polling if a fix was running; otherwise auto-check status.
   useEffect(() => {
     const serverApi = getServerApi();
     if (!serverApi) return;
-    serverApi.callPluginMethod('get_fan_fix_progress', {}).then(({ result }) => {
-      const prog = result as FixProgressResult;
-      if (prog?.running) {
-        setPhase('fixing');
-        setProgressStep(prog.step || 'Running…');
-        startPolling();
+    const init = async () => {
+      try {
+        const { result } = await serverApi.callPluginMethod('get_fan_fix_progress', {});
+        const prog = result as FixProgressResult;
+        if (prog?.running) {
+          setPhase('fixing');
+          setProgressStep(prog.step || 'Running…');
+          startPolling();
+        } else {
+          setCheckingSupport(true);
+          await refreshSupportState();
+          setLastChecked(Date.now());
+          setCheckingSupport(false);
+        }
+      } catch {
+        // non-fatal
       }
-    }).catch(() => {});
+    };
+    init();
     return stopPolling;
-  }, [startPolling, stopPolling]);
+  }, [startPolling, stopPolling, refreshSupportState]);
 
-  return { phase, progressStep, errorMsg, checkingSupport, onApplyFix, onCheckAgain };
+  return { phase, progressStep, errorMsg, checkingSupport, lastChecked, onApplyFix, onCheckAgain };
 };
 
 export const useFullFanSpeedThreshold = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,16 +18,21 @@ import { Provider, useSelector } from 'react-redux';
 import { currentGameIdListener } from './backend/currentGameIdListener';
 import logo from '../assets/Icon.png';
 import FanPanel from './components/fan/FanPanel';
+import FanSupportFooter from './components/fan/FanSupportFooter';
 import AlsPanel from './components/als/ALSPanel';
 import ErrorBoundary from './components/ErrorBoundary';
 import OtaUpdates from './components/OtaUpdates';
 import { useChargeLimitEnabled } from './hooks/ui';
-import { useSupportsCustomFanCurves } from './hooks/fan';
+import { useFanFixFlow, useSupportsCustomFanCurves } from './hooks/fan';
 
 const Content: VFC<{ serverAPI?: ServerAPI }> = memo(() => {
   const loading = useSelector(getInitialLoading);
   const { chargeLimitEnabled, setChargeLimit } = useChargeLimitEnabled();
   const supportsAcpiCall = useSupportsCustomFanCurves();
+  // Lifted here so fix-flow state survives the FanSupportRepair → sliders
+  // transition and so FanSupportFooter can live below Remap Buttons.
+  const fixFlow = useFanFixFlow();
+
   if (loading) {
     return null;
   }
@@ -51,11 +56,16 @@ const Content: VFC<{ serverAPI?: ServerAPI }> = memo(() => {
         <ControllerLightingPanel />
       </ErrorBoundary>
       <ErrorBoundary title="Fan Panel">
-        <FanPanel />
+        <FanPanel fixFlow={fixFlow} />
       </ErrorBoundary>
       <ErrorBoundary title="Remap Buttons">
         <RemapButtons />
       </ErrorBoundary>
+      {supportsAcpiCall && (
+        <ErrorBoundary title="Fan Support">
+          <FanSupportFooter fixFlow={fixFlow} />
+        </ErrorBoundary>
+      )}
       <ErrorBoundary>
         <OtaUpdates />
       </ErrorBoundary>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import OtaUpdates from './components/OtaUpdates';
 import { useChargeLimitEnabled } from './hooks/ui';
 import { useFanFixFlow, useSupportsCustomFanCurves } from './hooks/fan';
+import { ENABLE_FAN_FIX } from './featureFlags';
 
 const Content: VFC<{ serverAPI?: ServerAPI }> = memo(() => {
   const loading = useSelector(getInitialLoading);
@@ -31,7 +32,8 @@ const Content: VFC<{ serverAPI?: ServerAPI }> = memo(() => {
   const supportsAcpiCall = useSupportsCustomFanCurves();
   // Lifted here so fix-flow state survives the FanSupportRepair → sliders
   // transition and so FanSupportFooter can live below Remap Buttons.
-  const fixFlow = useFanFixFlow();
+  const fixFlowData = useFanFixFlow();
+  const fixFlow = ENABLE_FAN_FIX ? fixFlowData : null;
 
   if (loading) {
     return null;
@@ -61,7 +63,7 @@ const Content: VFC<{ serverAPI?: ServerAPI }> = memo(() => {
       <ErrorBoundary title="Remap Buttons">
         <RemapButtons />
       </ErrorBoundary>
-      {supportsAcpiCall && (
+      {supportsAcpiCall && fixFlow && (
         <ErrorBoundary title="Fan Support">
           <FanSupportFooter fixFlow={fixFlow} />
         </ErrorBoundary>

--- a/src/redux-modules/fanSlice.tsx
+++ b/src/redux-modules/fanSlice.tsx
@@ -113,6 +113,9 @@ export const fanSlice = createSlice({
     },
     updateFanProfiles: (state, action: PayloadAction<FanProfiles>) => {
       merge(state.fanProfiles, action.payload);
+    },
+    setSupportsCustomFanCurves: (state, action: PayloadAction<boolean>) => {
+      state.supportsCustomFanCurves = action.payload;
     }
   },
   extraReducers: (builder) => {

--- a/src/redux-modules/fanSlice.tsx
+++ b/src/redux-modules/fanSlice.tsx
@@ -27,7 +27,8 @@ const DEFAULT_FAN_VALUES: FanProfile = {
   80: 80,
   90: 95,
   100: 100,
-  fullFanSpeedEnabled: false
+  fullFanSpeedEnabled: false,
+  fullFanSpeedThreshold: null
 };
 
 type FanSpeed = number;
@@ -47,6 +48,7 @@ type FanCurve = {
 
 interface FanProfile extends FanCurve {
   fullFanSpeedEnabled: boolean;
+  fullFanSpeedThreshold?: number | null;
 }
 
 type FanProfiles = {
@@ -95,6 +97,18 @@ export const fanSlice = createSlice({
         state.fanProfiles[currentGameId].fullFanSpeedEnabled = enabled;
       } else {
         state.fanProfiles.default.fullFanSpeedEnabled = enabled;
+      }
+    },
+    setFullFanSpeedThreshold: (state, action: PayloadAction<number | null>) => {
+      const threshold = action.payload;
+
+      const perGameProfilesEnabled = state.fanPerGameProfilesEnabled;
+
+      if (perGameProfilesEnabled) {
+        const currentGameId = extractCurrentGameId();
+        state.fanProfiles[currentGameId].fullFanSpeedThreshold = threshold;
+      } else {
+        state.fanProfiles.default.fullFanSpeedThreshold = threshold;
       }
     },
     updateFanCurve: (
@@ -182,6 +196,7 @@ export const selectActiveFanCurve = (state: RootState) => {
 
   const p = cloneDeep(profile) as any;
   delete p.fullFanSpeedEnabled;
+  delete p.fullFanSpeedThreshold;
   const x = p as FanCurve;
 
   return x;
@@ -192,6 +207,11 @@ export const selectEnableFullFanSpeedMode = (state: RootState) => {
   return Boolean(profile.fullFanSpeedEnabled);
 };
 
+export const selectFullFanSpeedThreshold = (state: RootState) => {
+  const profile = selectActiveFanProfile(state);
+  return profile?.fullFanSpeedThreshold ?? null;
+};
+
 // -------------
 // middleware
 // -------------
@@ -200,7 +220,8 @@ const mutatingActionTypes = [
   fanSlice.actions.setFanPerGameProfilesEnabled.type,
   fanSlice.actions.updateFanCurve.type,
   fanSlice.actions.updateFanProfiles.type,
-  fanSlice.actions.setEnableFullFanSpeedMode.type
+  fanSlice.actions.setEnableFullFanSpeedMode.type,
+  fanSlice.actions.setFullFanSpeedThreshold.type
 ];
 
 export const saveFanSettingsMiddleware =

--- a/testing/README.md
+++ b/testing/README.md
@@ -11,12 +11,26 @@ repair cycle without waiting for one.
 - Fan curves responding normally (ACPI fan support active)
 - `sudo` access on the device
 
+## Install the Test Release
+
+The `testing/` directory is only included in the fork's test release, not the
+original plugin release. Install it first:
+
+```bash
+curl -L https://github.com/kjroberts39/LegionGoRemapperWithAutoFanSetup/releases/download/v0.3.1/LegionGoRemapper.tar.gz -o /tmp/LegionGoRemapper.tar.gz
+sudo HOME=/home/deck sh ~/homebrew/plugins/LegionGoRemapper/ota_update.sh
+```
+
+> **Note:** Use `sudo HOME=/home/deck sh` rather than just `sudo sh` — sudo
+> resets `$HOME` to `/root` which causes the install script to look in the
+> wrong place.
+
 ## Typical Test Workflow
 
 ### 1. Confirm healthy baseline
 
 ```bash
-./testing/test_fan_fix.sh baseline
+~/homebrew/plugins/LegionGoRemapper/testing/test_fan_fix.sh baseline
 ```
 
 Verifies that DKMS is registered, the `.ko` file is present, and the module is
@@ -25,12 +39,15 @@ loaded. Also confirms fan curves are working before you break anything.
 ### 2. Simulate the broken state
 
 ```bash
-sudo ./testing/test_fan_fix.sh break
+sudo bash ~/homebrew/plugins/LegionGoRemapper/testing/test_fan_fix.sh break
 ```
 
 Removes the DKMS registration and the `.ko` file for the running kernel, then
 restarts Decky. This is the most common real-world failure scenario (kernel
 update wiped the module).
+
+> **Note:** Use `sudo bash <path>` rather than `sudo <path>` — the script file
+> permissions prevent sudo from executing it directly.
 
 After this runs, open the Legion Go Remapper panel in Decky — the Fan Control
 section should switch from the normal curve sliders to the **repair UI** with
@@ -45,7 +62,7 @@ or **Reboot** depending on whether the module loaded live.
 ### 4. Verify the fix worked
 
 ```bash
-./testing/test_fan_fix.sh verify-fix
+~/homebrew/plugins/LegionGoRemapper/testing/test_fan_fix.sh verify-fix
 ```
 
 Checks that DKMS shows the module as installed, the `.ko` file is back, and the
@@ -60,9 +77,9 @@ These test less common failure modes that the fix also handles:
 
 | Command | What it simulates |
 |---|---|
-| `sudo ./testing/test_fan_fix.sh break-keyring` | Uninitialized pacman keyring (fresh install / factory reset) |
-| `sudo ./testing/test_fan_fix.sh break-headers` | Missing kernel headers build path |
-| `sudo ./testing/test_fan_fix.sh break-dkms-only` | DKMS registration missing but `.ko` still present |
+| `sudo bash .../test_fan_fix.sh break-keyring` | Uninitialized pacman keyring (fresh install / factory reset) |
+| `sudo bash .../test_fan_fix.sh break-headers` | Missing kernel headers build path |
+| `sudo bash .../test_fan_fix.sh break-dkms-only` | DKMS registration missing but `.ko` still present |
 
 For a complete test of `break-keyring`, run `break` first, then `break-keyring`.
 
@@ -73,7 +90,7 @@ For a complete test of `break-keyring`, run `break` first, then `break-keyring`.
 If something goes wrong and Decky is unavailable:
 
 ```bash
-sudo ./testing/test_fan_fix.sh restore
+sudo bash ~/homebrew/plugins/LegionGoRemapper/testing/test_fan_fix.sh restore
 ```
 
 Runs the same steps as the plugin (keyring init, headers install, DKMS build,
@@ -84,7 +101,7 @@ modprobe) directly from the shell.
 ## Status at Any Time
 
 ```bash
-./testing/test_fan_fix.sh status
+~/homebrew/plugins/LegionGoRemapper/testing/test_fan_fix.sh status
 ```
 
 Prints the current state of the ACPI module, DKMS registration, `.ko` file,

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,99 @@
+# Testing the Fan Fix Flow
+
+The fan fix flow repairs ACPI fan support when it goes missing after a SteamOS
+kernel update. Because the broken state only occurs naturally after an update,
+`test_fan_fix.sh` lets you simulate it on demand so you can test the full
+repair cycle without waiting for one.
+
+## Prerequisites
+
+- Legion Go Remapper installed and working in Decky
+- Fan curves responding normally (ACPI fan support active)
+- `sudo` access on the device
+
+## Typical Test Workflow
+
+### 1. Confirm healthy baseline
+
+```bash
+./testing/test_fan_fix.sh baseline
+```
+
+Verifies that DKMS is registered, the `.ko` file is present, and the module is
+loaded. Also confirms fan curves are working before you break anything.
+
+### 2. Simulate the broken state
+
+```bash
+sudo ./testing/test_fan_fix.sh break
+```
+
+Removes the DKMS registration and the `.ko` file for the running kernel, then
+restarts Decky. This is the most common real-world failure scenario (kernel
+update wiped the module).
+
+After this runs, open the Legion Go Remapper panel in Decky — the Fan Control
+section should switch from the normal curve sliders to the **repair UI** with
+an **Apply Fan Fix** button.
+
+### 3. Apply the fix via the UI
+
+In the Decky panel, click **Apply Fan Fix** and confirm the dialog. Watch the
+progress steps. When it finishes, the modal will prompt you to **Restart Decky**
+or **Reboot** depending on whether the module loaded live.
+
+### 4. Verify the fix worked
+
+```bash
+./testing/test_fan_fix.sh verify-fix
+```
+
+Checks that DKMS shows the module as installed, the `.ko` file is back, and the
+module is loaded in memory. After this passes, confirm fan curves are responding
+again in the Decky panel.
+
+---
+
+## Other Break Scenarios
+
+These test less common failure modes that the fix also handles:
+
+| Command | What it simulates |
+|---|---|
+| `sudo ./testing/test_fan_fix.sh break-keyring` | Uninitialized pacman keyring (fresh install / factory reset) |
+| `sudo ./testing/test_fan_fix.sh break-headers` | Missing kernel headers build path |
+| `sudo ./testing/test_fan_fix.sh break-dkms-only` | DKMS registration missing but `.ko` still present |
+
+For a complete test of `break-keyring`, run `break` first, then `break-keyring`.
+
+---
+
+## Emergency Restore (without the plugin)
+
+If something goes wrong and Decky is unavailable:
+
+```bash
+sudo ./testing/test_fan_fix.sh restore
+```
+
+Runs the same steps as the plugin (keyring init, headers install, DKMS build,
+modprobe) directly from the shell.
+
+---
+
+## Status at Any Time
+
+```bash
+./testing/test_fan_fix.sh status
+```
+
+Prints the current state of the ACPI module, DKMS registration, `.ko` file,
+kernel headers, and pacman keyring without making any changes.
+
+---
+
+## Feature Flag
+
+If you want to disable the fan fix UI without removing the code, set
+`ENABLE_FAN_FIX = false` in [`src/featureFlags.ts`](../src/featureFlags.ts)
+and rebuild.

--- a/testing/test_fan_fix.sh
+++ b/testing/test_fan_fix.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# test_fan_fix.sh — Repeatable end-to-end test for LegionFanFix
+#
+# Usage:
+#   ./test_fan_fix.sh baseline          # Phase 1 — confirm fan control is working
+#   ./test_fan_fix.sh break             # Phase 2 — simulate broken state (requires sudo)
+#   ./test_fan_fix.sh break-keyring     # Phase 2b — simulate uninitialized pacman keyring (requires sudo)
+#   ./test_fan_fix.sh break-headers     # Phase 2c — simulate missing kernel headers (requires sudo)
+#   ./test_fan_fix.sh break-dkms-only   # Phase 2d — remove DKMS registration but keep .ko (requires sudo)
+#   ./test_fan_fix.sh verify-fix        # Phase 3 — confirm plugin fixed it
+#   ./test_fan_fix.sh restore           # Emergency: manually restore without the plugin (requires sudo)
+#   ./test_fan_fix.sh status            # Print raw diagnostic state at any time
+
+set -eo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+ok()   { echo -e "${GREEN}  ✓ $*${RESET}"; }
+fail() { echo -e "${RED}  ✗ $*${RESET}"; }
+info() { echo -e "${CYAN}  → $*${RESET}"; }
+warn() { echo -e "${YELLOW}  ⚠ $*${RESET}"; }
+hdr()  { echo -e "\n${BOLD}$*${RESET}"; printf '%.0s─' $(seq 1 ${#1}); echo; }
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+acpi_loaded()    { [ -d /sys/module/acpi_call ]; }
+
+dkms_installed() {
+    local kernel; kernel=$(uname -r)
+    command -v dkms &>/dev/null && dkms status 2>/dev/null | grep -q "acpi_call.*${kernel}.*installed"
+}
+
+ko_present() {
+    local kernel; kernel=$(uname -r)
+    [[ $(find "/lib/modules/${kernel}" -name "acpi_call.ko*" 2>/dev/null | wc -l) -gt 0 ]]
+}
+
+headers_present() {
+    local kernel; kernel=$(uname -r)
+    [[ -d "/usr/lib/modules/${kernel}/build" ]]
+}
+
+keyring_ok() {
+    [[ -f /etc/pacman.d/gnupg/pubring.gpg ]] || [[ -f /etc/pacman.d/gnupg/trustdb.gpg ]]
+}
+
+# Derive the Valve series-specific headers package name from the running kernel.
+# e.g. 6.11.11-valve27-1-neptune-... → linux-neptune-611-headers
+neptune_headers_pkg() {
+    local kernel; kernel=$(uname -r)
+    local major minor
+    major=$(echo "$kernel" | cut -d. -f1)
+    minor=$(echo "$kernel" | cut -d. -f2)
+    echo "linux-neptune-${major}${minor}-headers"
+}
+
+require_sudo() {
+    if [[ $EUID -ne 0 ]]; then
+        fail "This phase requires sudo. Re-run with: sudo $0 $1"
+        exit 1
+    fi
+}
+
+print_status() {
+    hdr "Current State"
+    local kernel; kernel=$(uname -r)
+    info "Kernel: ${kernel}"
+    info "Expected headers pkg: $(neptune_headers_pkg)"
+    echo ""
+
+    if acpi_loaded; then
+        ok "acpi_call module is LOADED in memory"
+    else
+        fail "acpi_call module is NOT loaded"
+    fi
+
+    if dkms_installed; then
+        ok "DKMS shows acpi_call as installed for ${kernel}"
+    else
+        fail "DKMS does NOT show acpi_call as installed for ${kernel}"
+    fi
+
+    if ko_present; then
+        ok ".ko file present in /lib/modules/${kernel}"
+    else
+        fail ".ko file absent from /lib/modules/${kernel}"
+    fi
+
+    if headers_present; then
+        ok "Kernel headers build path present for ${kernel}"
+    else
+        warn "Kernel headers build path absent for ${kernel}"
+    fi
+
+    if keyring_ok; then
+        ok "pacman keyring appears initialized"
+    else
+        warn "pacman keyring may not be initialized (/etc/pacman.d/gnupg/)"
+    fi
+
+    echo ""
+    info "dkms status:"
+    command -v dkms &>/dev/null && dkms status 2>/dev/null || echo "    (dkms not available or no entries)"
+}
+
+# ─── Phases ───────────────────────────────────────────────────────────────────
+
+phase_baseline() {
+    hdr "Phase 1 — Baseline"
+    print_status
+
+    if acpi_loaded && dkms_installed; then
+        echo ""
+        ok "System is healthy — fan control should be working."
+        warn "ACTION: Confirm fan curves respond in Legion Go Remapper."
+        warn "        When confirmed, choose a break phase:"
+        warn "          sudo ./test_fan_fix.sh break             (standard)"
+        warn "          sudo ./test_fan_fix.sh break-keyring     (keyring scenario)"
+        warn "          sudo ./test_fan_fix.sh break-headers     (missing headers scenario)"
+        warn "          sudo ./test_fan_fix.sh break-dkms-only   (DKMS-only scenario)"
+    else
+        echo ""
+        fail "System is not in a healthy baseline state."
+        warn "Run the LegionFanFix plugin first, or: sudo ./test_fan_fix.sh restore"
+        exit 1
+    fi
+}
+
+phase_break() {
+    require_sudo "break"
+    hdr "Phase 2 — Simulate Broken State (DKMS + .ko removed)"
+
+    local kernel; kernel=$(uname -r)
+
+    if command -v dkms &>/dev/null; then
+        local ver
+        ver=$(dkms status 2>/dev/null | grep -i acpi_call | head -1 | sed 's/acpi_call\/\([^,]*\).*/\1/' || true)
+        if [[ -n "$ver" ]]; then
+            info "Removing DKMS registration (acpi_call/${ver})…"
+            dkms remove "acpi_call/${ver}" --all 2>/dev/null || true
+            ok "DKMS registration removed."
+        else
+            warn "No acpi_call entry in dkms status — skipping dkms remove."
+        fi
+    else
+        warn "dkms not found — skipping dkms remove."
+    fi
+
+    info "Disabling read-only filesystem to remove module file…"
+    steamos-readonly disable
+
+    info "Removing built module file from current kernel…"
+    if ko_present; then
+        find "/lib/modules/${kernel}" -name "acpi_call.ko*" -delete
+        depmod -a
+        ok "Module file(s) removed and module database updated."
+    else
+        warn "No acpi_call.ko found — may already be gone."
+    fi
+
+    info "Re-enabling read-only filesystem…"
+    steamos-readonly enable
+
+    echo ""
+    print_status
+    echo ""
+
+    if ! dkms_installed && ! ko_present; then
+        ok "Broken state confirmed — DKMS unregistered and .ko file gone."
+        _restart_decky_and_prompt "break"
+    else
+        fail "Something is still active — check the state above."
+        exit 1
+    fi
+}
+
+# Phase 2b: simulate uninitialized pacman keyring.
+# This reproduces the "Public keyring not found / keyring is not writable"
+# error that occurs when pacman-key has never been run (e.g. fresh SteamOS
+# install or after a factory reset).
+phase_break_keyring() {
+    require_sudo "break-keyring"
+    hdr "Phase 2b — Simulate Uninitialized pacman Keyring"
+
+    info "Disabling read-only filesystem…"
+    steamos-readonly disable
+
+    if [[ -d /etc/pacman.d/gnupg ]]; then
+        info "Backing up existing keyring to /etc/pacman.d/gnupg.bak…"
+        rm -rf /etc/pacman.d/gnupg.bak
+        cp -a /etc/pacman.d/gnupg /etc/pacman.d/gnupg.bak
+        info "Removing keyring contents…"
+        rm -rf /etc/pacman.d/gnupg
+        ok "Keyring removed. (backup at /etc/pacman.d/gnupg.bak)"
+    else
+        warn "Keyring directory not found — already in broken state."
+    fi
+
+    info "Re-enabling read-only filesystem…"
+    steamos-readonly enable
+
+    echo ""
+    print_status
+    echo ""
+    ok "Keyring broken state set."
+    warn "NOTE: The fan .ko is still present/loaded — this only tests whether"
+    warn "      the fix can reinstall packages when the keyring is absent."
+    warn "      For a full test, run 'sudo ./test_fan_fix.sh break' first,"
+    warn "      then 'sudo ./test_fan_fix.sh break-keyring'."
+    echo ""
+    warn "ACTION: Apply the fix via LegionFanFix in Decky, then:"
+    warn "        ./test_fan_fix.sh verify-fix"
+    echo ""
+    warn "To restore the keyring manually without the plugin:"
+    warn "  sudo steamos-readonly disable"
+    warn "  sudo cp -a /etc/pacman.d/gnupg.bak /etc/pacman.d/gnupg"
+    warn "  sudo steamos-readonly enable"
+}
+
+# Phase 2c: simulate missing kernel headers (the build path is absent).
+# This reproduces the DKMS "cannot be found at .../build" error that occurs
+# when linux-neptune-{series}-headers has never been installed, or after a
+# SteamOS update before the matching headers package existed.
+phase_break_headers() {
+    require_sudo "break-headers"
+    hdr "Phase 2c — Simulate Missing Kernel Headers"
+
+    local kernel; kernel=$(uname -r)
+    local build_path="/usr/lib/modules/${kernel}/build"
+    local source_path="/usr/lib/modules/${kernel}/source"
+
+    if ! headers_present; then
+        warn "Headers build path already absent for ${kernel} — already broken."
+        print_status
+        exit 0
+    fi
+
+    info "Disabling read-only filesystem…"
+    steamos-readonly disable
+
+    if [[ -L "$build_path" || -d "$build_path" ]]; then
+        info "Backing up build path…"
+        mv "$build_path" "${build_path}.bak"
+        ok "Moved ${build_path} → ${build_path}.bak"
+    fi
+    if [[ -L "$source_path" || -d "$source_path" ]]; then
+        mv "$source_path" "${source_path}.bak"
+        ok "Moved ${source_path} → ${source_path}.bak"
+    fi
+
+    info "Re-enabling read-only filesystem…"
+    steamos-readonly enable
+
+    echo ""
+    print_status
+    echo ""
+    ok "Headers broken state set — build path removed for ${kernel}."
+    warn "ACTION: Apply the fix via LegionFanFix in Decky, then:"
+    warn "        ./test_fan_fix.sh verify-fix"
+    echo ""
+    warn "To restore headers manually:"
+    warn "  sudo steamos-readonly disable"
+    warn "  sudo mv ${build_path}.bak ${build_path}"
+    warn "  sudo steamos-readonly enable"
+}
+
+# Phase 2d: remove only the DKMS registration, leaving the .ko in place.
+# Tests whether the fix handles the case where DKMS thinks the module is
+# not installed but the .ko file still exists (e.g. after dkms database
+# corruption or a pacman upgrade that wiped DKMS entries).
+phase_break_dkms_only() {
+    require_sudo "break-dkms-only"
+    hdr "Phase 2d — Simulate Missing DKMS Registration (keep .ko)"
+
+    if ! command -v dkms &>/dev/null; then
+        fail "dkms not installed — cannot simulate this scenario."
+        exit 1
+    fi
+
+    local ver
+    ver=$(dkms status 2>/dev/null | grep -i acpi_call | head -1 | sed 's/acpi_call\/\([^,]*\).*/\1/' || true)
+    if [[ -z "$ver" ]]; then
+        warn "No acpi_call DKMS entry found — already in target state."
+        print_status
+        exit 0
+    fi
+
+    info "Removing DKMS registration for acpi_call/${ver} (keeping .ko)…"
+    # dkms remove without --all only removes the registration for this kernel.
+    dkms remove "acpi_call/${ver}" --all 2>/dev/null || true
+    ok "DKMS registration removed."
+
+    echo ""
+    print_status
+    echo ""
+    if ! dkms_installed; then
+        ok "DKMS-only broken state confirmed — registration gone, .ko may still be present."
+        _restart_decky_and_prompt "break-dkms-only"
+    else
+        fail "DKMS entry still present — check output above."
+        exit 1
+    fi
+}
+
+_restart_decky_and_prompt() {
+    local phase="$1"
+    info "Restarting Decky to load latest plugin build…"
+    pkill -f "PluginLoader" 2>/dev/null || true
+    sleep 3
+    ok "Decky restarted."
+    echo ""
+    warn "ACTION: Apply the fix using LegionFanFix in the Decky menu."
+    warn "        When the modal appears, choose 'Restart Decky', then:"
+    warn "        ./test_fan_fix.sh verify-fix"
+}
+
+phase_verify_fix() {
+    hdr "Phase 3 — Verify Fix Applied"
+    print_status
+
+    local pass=true
+    echo ""
+
+    if dkms_installed; then
+        ok "DKMS shows acpi_call as installed for $(uname -r)"
+    else
+        fail "DKMS does NOT show acpi_call installed — fix may have failed."
+        pass=false
+    fi
+
+    if ko_present; then
+        ok ".ko file is present for $(uname -r)"
+    else
+        fail ".ko file is missing — fix may have failed."
+        pass=false
+    fi
+
+    if acpi_loaded; then
+        ok "acpi_call module is loaded in memory."
+    else
+        fail "acpi_call module is NOT loaded."
+        warn "Try manually: sudo /usr/bin/modprobe acpi_call"
+        pass=false
+    fi
+
+    if headers_present; then
+        ok "Kernel headers build path present."
+    else
+        warn "Kernel headers build path absent — future DKMS rebuilds may fail."
+    fi
+
+    echo ""
+    if $pass; then
+        ok "All checks passed."
+        warn "ACTION: Confirm fan curves respond in Legion Go Remapper."
+    else
+        fail "One or more checks failed — review output above."
+        exit 1
+    fi
+}
+
+phase_restore() {
+    require_sudo "restore"
+    hdr "Emergency Restore (without the plugin)"
+    warn "Runs the same steps as the plugin — use if Decky is unavailable."
+
+    local kernel; kernel=$(uname -r)
+
+    info "Disabling read-only filesystem…"
+    steamos-readonly disable
+
+    info "Initializing pacman keyring…"
+    pacman-key --init || warn "pacman-key --init failed (may already be initialized)"
+    pacman-key --populate archlinux holo || warn "pacman-key --populate failed"
+
+    # Derive the series-specific headers package (e.g. linux-neptune-611-headers).
+    local major minor series headers_pkg
+    major=$(echo "$kernel" | cut -d. -f1)
+    minor=$(echo "$kernel" | cut -d. -f2)
+    series="${major}${minor}"
+    headers_pkg="linux-neptune-${series}-headers"
+
+    info "Installing kernel headers (${headers_pkg}) and DKMS packages…"
+    if ! pacman -S --noconfirm "$headers_pkg" dkms acpi_call-dkms; then
+        warn "Series-specific headers failed; falling back to linux-neptune-headers…"
+        pacman -S --noconfirm linux-neptune-headers dkms acpi_call-dkms
+    fi
+
+    if ! dkms_installed; then
+        local ver
+        ver=$(pacman -Q acpi_call-dkms | awk '{print $2}' | cut -d- -f1)
+        info "Building acpi_call/${ver} for ${kernel}…"
+        local build_path="/usr/lib/modules/${kernel}/build"
+        if [[ ! -d "$build_path" ]]; then
+            fail "Headers build path still absent after install — cannot build module."
+            warn "If SteamOS has a pending update, reboot first then re-run this script."
+            steamos-readonly enable
+            exit 1
+        fi
+        dkms install "acpi_call/${ver}" -k "${kernel}"
+    fi
+
+    info "Re-enabling read-only filesystem…"
+    steamos-readonly enable
+
+    info "Loading module…"
+    /usr/bin/modprobe acpi_call
+
+    echo ""
+    print_status
+    ok "Restore complete."
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+PHASE="${1:-status}"
+
+case "$PHASE" in
+    baseline)         phase_baseline ;;
+    break)            phase_break ;;
+    break-keyring)    phase_break_keyring ;;
+    break-headers)    phase_break_headers ;;
+    break-dkms-only)  phase_break_dkms_only ;;
+    verify-fix)       phase_verify_fix ;;
+    restore)          phase_restore ;;
+    status)           print_status ;;
+    *)
+        echo "Usage: $0 {baseline|break|break-keyring|break-headers|break-dkms-only|verify-fix|restore|status}"
+        echo ""
+        echo "  baseline          Phase 1: confirm healthy starting state"
+        echo "  break             Phase 2: remove DKMS + .ko (requires sudo)"
+        echo "  break-keyring     Phase 2b: corrupt pacman keyring (requires sudo)"
+        echo "  break-headers     Phase 2c: remove kernel headers build path (requires sudo)"
+        echo "  break-dkms-only   Phase 2d: remove DKMS registration, keep .ko (requires sudo)"
+        echo "  verify-fix        Phase 3: confirm plugin fix worked"
+        echo "  restore           Emergency manual restore (requires sudo)"
+        echo "  status            Print current acpi_call / DKMS / headers / keyring state"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

- **ACPI fan support repair**: When a SteamOS kernel update breaks the `acpi_call` DKMS module (causing fan curves to stop responding), a "NOT ACTIVE" warning appears in the Fan Control section with an **Apply Fan Fix** button. The fix reinstalls kernel headers, rebuilds the DKMS module, and prompts to restart Decky — all without leaving the plugin panel.
- **Full-speed threshold toggle**: Each temperature step in the fan curve editor now has an optional toggle to engage full fan speed at that temperature. Enabling one collapses all higher steps (since they're superseded) and drives the existing fan watchdog.
- **Feature flag**: The repair UI is gated behind `ENABLE_FAN_FIX` in `src/featureFlags.ts` and can be disabled without removing any code.

## Fan Fix UI

_Fan support not active — Apply Fan Fix button appears in place of the curve editor_

<a href="https://github.com/user-attachments/assets/24424797-eff2-4ba7-bb6d-d361a46d6926"><img width="250" src="https://github.com/user-attachments/assets/24424797-eff2-4ba7-bb6d-d361a46d6926" /></a>

<details>
<summary>Fix flow (confirmation → progress steps → completion)</summary>

<br>

<a href="https://github.com/user-attachments/assets/7c7a4552-05f7-4760-ba6a-9f3a98550110"><img width="400" src="https://github.com/user-attachments/assets/7c7a4552-05f7-4760-ba6a-9f3a98550110" /></a>

<br>

<a href="https://github.com/user-attachments/assets/fe3e748e-d783-465d-81b0-aff8cd648b90"><img width="250" src="https://github.com/user-attachments/assets/fe3e748e-d783-465d-81b0-aff8cd648b90" /></a>

<br>

<a href="https://github.com/user-attachments/assets/df91ca44-c075-44f0-b417-34064ceb56a4"><img width="250" src="https://github.com/user-attachments/assets/df91ca44-c075-44f0-b417-34064ceb56a4" /></a>

<br>

<a href="https://github.com/user-attachments/assets/de1c9040-ee28-489b-b2ed-ee1b9448bc53"><img width="250" src="https://github.com/user-attachments/assets/de1c9040-ee28-489b-b2ed-ee1b9448bc53" /></a>

<br>

<a href="https://github.com/user-attachments/assets/59ae3c0a-37ff-4044-a0ba-1c3cd9fad557"><img width="250" src="https://github.com/user-attachments/assets/59ae3c0a-37ff-4044-a0ba-1c3cd9fad557" /></a>

<br>

<a href="https://github.com/user-attachments/assets/62d50405-08b1-4c43-9050-45c0d5e1c7aa"><img width="400" src="https://github.com/user-attachments/assets/62d50405-08b1-4c43-9050-45c0d5e1c7aa" /></a>

<br>

<a href="https://github.com/user-attachments/assets/1bc0181f-b99c-4157-99fa-7b29e07512d9"><img width="400" src="https://github.com/user-attachments/assets/1bc0181f-b99c-4157-99fa-7b29e07512d9" /></a>

<br>

<a href="https://github.com/user-attachments/assets/9549eaf9-3add-4b5b-b7e0-de11dcdd949e"><img width="250" src="https://github.com/user-attachments/assets/9549eaf9-3add-4b5b-b7e0-de11dcdd949e" /></a>

</details>

<br>

_After restart — Fan Support shows ACTIVE, curve editor is restored_

<a href="https://github.com/user-attachments/assets/5bf9e9fe-cb8e-46a0-b6c2-30a82352e698"><img width="250" src="https://github.com/user-attachments/assets/5bf9e9fe-cb8e-46a0-b6c2-30a82352e698" /></a>

## Full Speed Threshold Toggle

_Toggle appears after each temperature step at 60°C and above_

<a href="https://github.com/user-attachments/assets/dd04ba54-40d0-4060-9268-ca20f9b6bbae"><img width="250" src="https://github.com/user-attachments/assets/dd04ba54-40d0-4060-9268-ca20f9b6bbae" /></a>

<details>
<summary>Toggle enabled — collapses higher steps</summary>

<br>

<a href="https://github.com/user-attachments/assets/d077a2ea-d27a-4b00-ad0a-2a8960af53db"><img width="250" src="https://github.com/user-attachments/assets/d077a2ea-d27a-4b00-ad0a-2a8960af53db" /></a>

<br>

<a href="https://github.com/user-attachments/assets/c3083735-3987-4106-b568-828f1c9805cc"><img width="250" src="https://github.com/user-attachments/assets/c3083735-3987-4106-b568-828f1c9805cc" /></a>

</details>

## Testing

To test the full fan fix flow, install from my fork's release and follow `testing/README.md`:

```bash
curl -L https://github.com/kjroberts39/LegionGoRemapperWithAutoFanSetup/releases/download/v0.3.1/LegionGoRemapper.tar.gz -o /tmp/LegionGoRemapper.tar.gz
sudo HOME=/home/deck sh ~/homebrew/plugins/LegionGoRemapper/ota_update.sh